### PR TITLE
Added code to rank daughters by pt in FSA

### DIFF
--- a/PatTools/plugins/PATRankEmbedder.cc
+++ b/PatTools/plugins/PATRankEmbedder.cc
@@ -1,0 +1,19 @@
+#include "FinalStateAnalysis/PatTools/plugins/PATRankEmbedder.h"
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/PatCandidates/interface/Tau.h"
+
+typedef PATRankEmbedder<pat::Muon> PATMuonRanker;
+typedef PATRankEmbedder<pat::Jet> PATJetRanker;
+typedef PATRankEmbedder<pat::Electron> PATElectronRanker;
+typedef PATRankEmbedder<pat::Tau> PATTauRanker;
+
+DEFINE_FWK_MODULE(PATMuonRanker);
+DEFINE_FWK_MODULE(PATJetRanker);
+DEFINE_FWK_MODULE(PATElectronRanker);
+DEFINE_FWK_MODULE(PATTauRanker);
+
+

--- a/PatTools/plugins/PATRankEmbedder.h
+++ b/PatTools/plugins/PATRankEmbedder.h
@@ -1,0 +1,57 @@
+/*
+ * Pat objects originally are sorted by Pt 
+ * FSA reorders them so that the highest Pt "fsa" object is the first in the collection
+ * This combinatoric approach is good for searches, but not for SMP
+ * Incorporating a "rankByPt" variable that gives the position of the object in the collection, by Pt
+ * Could be refined, and some care has to be taken if cuts are applied to the collection before being handled in the ntuple
+ *
+ * Author: M.C., UW Madison
+ *
+ */
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include <vector>
+#include <string>
+#include "DataFormats/Candidate/interface/Candidate.h"
+
+template<typename T>
+class PATRankEmbedder : public edm::EDProducer {
+  typedef std::vector<T> TCollection;
+  public:
+    virtual ~PATRankEmbedder(){}
+
+    void produce(edm::Event& evt, const edm::EventSetup& es);
+
+    inline bool ptComparator(const reco::Candidate* a , const reco::Candidate* b) {return a->pt() > b->pt(); }
+ 
+    PATRankEmbedder(const edm::ParameterSet& pset) :
+     src_ (pset.getParameter<edm::InputTag>("src")){
+     produces< TCollection >();}
+
+  private:
+    edm::InputTag src_;
+
+};
+
+template<typename T>
+void PATRankEmbedder< T>::produce(edm::Event& evt, const edm::EventSetup& es) {
+  std::auto_ptr<TCollection >output(new TCollection);
+
+  edm::Handle< TCollection > candidates;
+  evt.getByLabel(src_, candidates);
+  output->reserve(candidates->size());
+
+
+  for (size_t i = 0; i < candidates->size(); i++) {
+    T embedInto = candidates->at(i);
+    embedInto.addUserFloat("rankByPt",i);
+    output->push_back(embedInto); // takes ownership
+  }
+  evt.put(output);
+
+}
+


### PR DESCRIPTION
A producer to add "rankByPt" as userFloat to the candidates to have the information of the pt ordering of the daughters of the FS in the ntuple (implemented for Jet, Muon, Electron, Tau).

This is independent from the rest of the code, so merging should be straightforward.
