### PR TITLE
Switch to 'nfs_scratch'

### DIFF
--- a/PatTools/python/site_spec.py
+++ b/PatTools/python/site_spec.py
@@ -4,7 +4,7 @@ import sys
 _host_name = os.environ['HOSTNAME']
 _log_name  = os.environ['LOGNAME']
 
-submit_dir_root = '/scratch/%s'%_log_name
+submit_dir_root = '/nfs_scratch/%s'%_log_name
 output_dir_root = '/hdfs/store/user/%s'%_log_name
 output_dir_srm  = 'cmssrm.hep.wisc.edu:8443/srm/v2/server?SFN='
 
@@ -16,4 +16,4 @@ if 'fnal.gov' in _host_name:
 if 'hep.wisc.edu' in _host_name and 'lgray' in _log_name:
     output_dir_srm  = 'cmssrm.fnal.gov:8443/srm/managerv2?SFN='
     output_dir_root = '/11/store/user/lagray'
-    submit_dir_root = '/scratch/%s'%_log_name
+    submit_dir_root = '/nfs_scratch/%s'%_log_name

--- a/Utilities/scripts/submit_job.py
+++ b/Utilities/scripts/submit_job.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
 
     farmout_group.add_argument(
         '--output-dag-file', dest='dagdir',
-        default='/scratch/{user}/{jobid}/{sample}/dags/dag',
+        default='/nfs_scratch/{user}/{jobid}/{sample}/dags/dag',
         help = 'Where to put dag files',
     )
 
@@ -90,7 +90,7 @@ if __name__ == "__main__":
 
     farmout_group.add_argument(
         '--submit-dir', dest='subdir',
-        default='/scratch/{user}/{jobid}/{sample}/submit',
+        default='/nfs_scratch/{user}/{jobid}/{sample}/submit',
         help = 'Where to put submit files. Default: %s(default)s',
     )
 


### PR DESCRIPTION
As per Dan Bradley's email, farmoutAnalysisJobs now uses `/nfs_scratch` instead of `/scratch`.
