### PR TITLE
fix error with <() process substitution

### DIFF
--- a/Utilities/scripts/resubmit_failed_jobs.sh
+++ b/Utilities/scripts/resubmit_failed_jobs.sh
@@ -11,7 +11,7 @@
 
 if [ $# -lt 1 ]
 then
-    echo "Usage: resubmit_failed_jobs.sh JOB_ID"
+    echo "Usage: bash resubmit_failed_jobs.sh JOB_ID"
     exit 1
 fi
 


### PR DESCRIPTION
Fixing error to previous pull request with the process substitution. Running

```
resubmit_failed_jobs.sh JOBID
```

will no longer give an error.
