### PR TITLE
Fix impact parameter ntuple branches

### DIFF
--- a/DataFormats/interface/PATFinalState.h
+++ b/DataFormats/interface/PATFinalState.h
@@ -295,6 +295,12 @@ class PATFinalState : public pat::PATObject<reco::LeafCandidate> {
 
     double twoParticleDeltaPhiToMEt(const int i, const int j, const std::string& metTag) const;
     
+    const float getIP3D(const size_t i) const;
+
+    const float getIP3DSig(const size_t i) const;
+
+    const float getDZ(const size_t i) const;
+
   private:
     edm::Ptr<PATFinalStateEvent> event_;
 };

--- a/DataFormats/src/PATFinalState.cc
+++ b/DataFormats/src/PATFinalState.cc
@@ -6,6 +6,7 @@
 #include "FinalStateAnalysis/DataAlgos/interface/CollectionFilter.h"
 #include "FinalStateAnalysis/DataAlgos/interface/ApplySVfit.h"
 
+#include "DataFormats/PatCandidates/interface/PATObject.h"
 #include "DataFormats/PatCandidates/interface/Electron.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/PatCandidates/interface/Tau.h"
@@ -750,7 +751,7 @@ double PATFinalState::zCompatibility(int i, int j) const {
   if (likeSigned(i, j)) {
     return 1000;
   }
-  return std::abs(subcand(i, j)->mass() - 91.2);
+  return std::abs(subcand(i, j)->mass() - 91.1876);
 }
 
 VBFVariables PATFinalState::vbfVariables(const std::string& jetCuts) const {
@@ -893,4 +894,64 @@ const float PATFinalState::jetVariables(size_t i, const std::string& key) const 
     return evt()->jetVariables(daughterUserCand(i,"patJet"), key);
   }
   return -100; 
+}
+
+
+const float PATFinalState::getIP3D(const size_t i) const
+{
+  if(event_->isMiniAOD())
+    {
+      if(abs(daughter(i)->pdgId()) == 11)
+	{
+	  return fabs(daughterAsElectron(i)->dB(pat::Electron::PV3D));
+	}
+      else if (abs(daughter(i)->pdgId()) == 13)
+	{
+	  return fabs(daughterAsMuon(i)->dB(pat::Muon::PV3D));
+	}
+      
+      throw cms::Exception("InvalidParticle") << "FSA can only find SIP3D for electron and muon for now" << std::endl;
+    }
+
+  return dynamic_cast<const pat::PATObject<reco::Candidate>* >(daughter(i))->userFloat("ip3D");
+}
+
+const float PATFinalState::getIP3DSig(const size_t i) const
+{
+  if(event_->isMiniAOD())
+    {
+      if(abs(daughter(i)->pdgId()) == 11)
+	{
+	  return daughterAsElectron(i)->edB(pat::Electron::PV3D);
+	}
+      else if (abs(daughter(i)->pdgId()) == 13)
+	{
+	  return daughterAsMuon(i)->edB(pat::Muon::PV3D);
+	}
+      
+      throw cms::Exception("InvalidParticle") << "FSA can only find SIP3D for electron and muon for now" << std::endl;
+    }
+
+return static_cast<const pat::PATObject<reco::Candidate> *>(daughter(i))->userFloat("ip3DS");
+}
+
+const float PATFinalState::getDZ(const size_t i) const
+{
+  if(event_->isMiniAOD())
+    {
+      if(abs(daughter(i)->pdgId()) == 11)
+	{
+	  const edm::Ptr<reco::Vertex> pv = event_->pv();
+	  return daughterAsElectron(i)->gsfTrack()->dz(pv->position());
+	}
+      else if(abs(daughter(i)->pdgId()) == 13)
+	{
+	  const edm::Ptr<reco::Vertex> pv = event_->pv();
+	  return daughterAsMuon(i)->muonBestTrack()->dz(pv->position());
+	}
+      
+      throw cms::Exception("InvalidParticle") << "FSA can only find dZ for electron and muon for now" << std::endl;
+    }
+  
+  return dynamic_cast<const pat::PATObject<reco::Candidate> *>(daughter(i))->userFloat("dz");
 }

--- a/NtupleTools/python/ntuple_builder.py
+++ b/NtupleTools/python/ntuple_builder.py
@@ -70,7 +70,7 @@ _muon_template = PSet(
 _bjet_template= PSet(
     templates.bjets.btagging,
     templates.candidates.kinematics,
-    templates.candidates.vertex_info,
+#    templates.candidates.vertex_info, # Always filled with 0 as far as I can tell
 )
 
 _electron_template = PSet(
@@ -320,6 +320,15 @@ def make_ntuple(*legs, **kwargs):
             "t[1-9]?((V?Loose)|(Medium)|(Tight))Iso", # deprecated, could be changed to a different combined iso discriminator
             # topology.py
             "[emtgj][1-9]?MtToMVAMET", # not yet implemented in miniAOD
+            # candidates.py
+            "t[1-9]?IP3D(Sig)?", # tau impact parameter interface is weird, will add if anyone needs it
+            "t[1-9]?DZ",
+            #
+            # Remove because old
+            "[em][1-9]?((WW)|(MIT)|(CB))ID(_((LOOSE)|(MEDIUM)|(TIGHT)|(VETO)))?",
+            "eMVAIDH2TauWP",
+            "\w*201[12]\w*",
+            "\w*[(Fall)(Winter)(Spring)(Summer)]1[12]\w*",
             ]
 
         allRemovals = re.compile("(" + ")|(".join(notInMiniAOD) + ")")

--- a/NtupleTools/python/templates/candidates.py
+++ b/NtupleTools/python/templates/candidates.py
@@ -19,9 +19,10 @@ kinematics = PSet(
 )
 
 vertex_info = PSet(
-    objectDZ = '{object}.userFloat("dz")',
+    objectDZ = 'getDZ({object_idx})',
     objectVZ = '{object}.vz',
-    objectIP3DS = '{object}.userFloat("ip3DS")',
+    objectIP3D = 'getIP3D({object_idx})',
+    objectIP3DSig = 'getIP3DSig({object_idx})', # uncertainty ("significance") of IP3D
 )
 
 # The info about the associated pat::Jet


### PR DESCRIPTION
Removed them for taus because it's a pain (if somebody complains I'll add them back in) and jets because they never meaningfully had them anyway. Added IP3D branch and renamed IP3DS to IP3DSig because it was confusingly similar to SIP3D = IP3D/IP3DS.

Also removed a few old branches (more removals to come) and made a small number of little more-or-less cosmetic fixes.
