### PR TITLE
Fix jets and add available electron ids

### DIFF
--- a/DataFormats/src/PATFinalState.cc
+++ b/DataFormats/src/PATFinalState.cc
@@ -896,7 +896,6 @@ const float PATFinalState::jetVariables(size_t i, const std::string& key) const 
   return -100; 
 }
 
-
 const float PATFinalState::getIP3D(const size_t i) const
 {
   if(event_->isMiniAOD())

--- a/NtupleTools/python/ntuple_builder.py
+++ b/NtupleTools/python/ntuple_builder.py
@@ -311,7 +311,7 @@ def make_ntuple(*legs, **kwargs):
             # cleaning.py and electrons.py
             "[emtgj][1-9]?(Veto)?Ci[cC]Tight((ElecOverlap)|(Iso))?", # electron MVA not yet in miniAOD (or done at all)
             # electrons.py
-            "e[1-9]?MVA(Non)?Trig(IDISO)?(PUSUB)?", # electron MVA not yet in miniAOD (or done at all)
+            #"e[1-9]?MVA(Non)?Trig(IDISO)?(PUSUB)?",
             "e[1-9]?MVAIDH2TauWP",# electron MVA not yet in miniAOD (or done at all)
             # event.py
             "mva_met((Et)|(Phi))", # not yet implemented in miniAOD

--- a/NtupleTools/python/templates/electrons.py
+++ b/NtupleTools/python/templates/electrons.py
@@ -16,21 +16,32 @@ from FinalStateAnalysis.Utilities.cfgtools import PSet
 
 # ID and isolation
 id = PSet(
-    objectWWID = '{object}.userFloat("WWID")',
-    objectMITID = '{object}.userFloat("MITID")',
-    objectMVANonTrig = '{object}.electronID("mvaNonTrigV0")',
-    objectMVATrig = '{object}.electronID("mvaTrigV0")',
+    # mva ids added manually right now, only trig available https://twiki.cern.ch/twiki/bin/viewauth/CMS/MultivariateElectronIdentificationRun2
+    objectMVATrigCSA14 = '? {object}.isElectronIDAvailable("mvaTrigV0CSA14") ?{object}.electronID("mvaTrigV0CSA14") : {object}.userFloat("mvaTrigV0CSA14")',
+    #objectMVANonTrigCSA14 = '? {object}.isElectronIDAvailable("mvaNonTrigV0CSA14") ?{object}.electronID("mvaNonTrigV0CSA14") : -1',
+    objectMVANonTrig = '? {object}.isElectronIDAvailable("mvaNonTrigV0") ?{object}.electronID("mvaNonTrigV0") : -1',
+    objectMVATrig = '? {object}.isElectronIDAvailable("mvaTrigV0") ?{object}.electronID("mvaTrigV0") : -1',
     objectMVATrigIDISO = '? {object}.isElectronIDAvailable("mvaTrigIDISOV0") ?{object}.electronID("mvaTrigIDISOV0") : -1',
     objectMVATrigIDISOPUSUB = '? {object}.isElectronIDAvailable("mvaTrigIDISOPUSUBV0") ?{object}.electronID("mvaTrigIDISOPUSUBV0") : -1',
-    objectMVAIDH2TauWP = '{object}.userInt("mvaidwp")',
-    objectCiCTight = '{object}.electronID("cicTight")',
-    objectCBID_VETO = '{object}.userInt("CBID_VETO")',
-    objectCBID_LOOSE = '{object}.userInt("CBID_LOOSE")',
-    objectCBID_MEDIUM = '{object}.userInt("CBID_MEDIUM")',
-    objectCBID_TIGHT = '{object}.userInt("CBID_TIGHT")',
+    objectCiCTight = '?  {object}.isElectronIDAvailable("cicTight") ?{object}.electronID("cicTight") : -1',
+    # not implemented yet for miniAOD https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2
+    #objectCBID_VETO = '{object}.userInt("CBID_VETO")',
+    #objectCBID_LOOSE = '{object}.userInt("CBID_LOOSE")',
+    #objectCBID_MEDIUM = '{object}.userInt("CBID_MEDIUM")',
+    #objectCBID_TIGHT = '{object}.userInt("CBID_TIGHT")',
     #new Summer13 MVA ID
-    objectMVATrigNoIP = '{object}.userFloat("mvaTrigNoIP")',
-    
+    #objectMVATrigNoIP = '{object}.userFloat("mvaTrigNoIP")',
+
+    # CSA14 cutbased ids (TODO)    
+    objectCBIDCSA14_VETO_50ns = '? {object}.isElectronIDAvailable("egmGsfElectronIDs:cutBasedElectronID-CSA14-50ns-V1-standalone-veto") ?{object}.electronID("egmGsfElectronIDs:cutBasedElectronID-CSA14-50ns-V1-standalone-veto") : {object}.userFloat("cutBasedElectronID-CSA14-50ns-V1-standalone-veto")',
+    objectCBIDCSA14_LOOSE_50ns = '? {object}.isElectronIDAvailable("egmGsfElectronIDs:cutBasedElectronID-CSA14-50ns-V1-standalone-loose") ?{object}.electronID("egmGsfElectronIDs:cutBasedElectronID-CSA14-50ns-V1-standalone-loose") : {object}.userFloat("cutBasedElectronID-CSA14-50ns-V1-standalone-loose")',
+    objectCBIDCSA14_MEDIUM_50ns = '? {object}.isElectronIDAvailable("egmGsfElectronIDs:cutBasedElectronID-CSA14-50ns-V1-standalone-medium") ?{object}.electronID("egmGsfElectronIDs:cutBasedElectronID-CSA14-50ns-V1-standalone-medium") : {object}.userFloat("cutBasedElectronID-CSA14-50ns-V1-standalone-medium")',
+    objectCBIDCSA14_TIGHT_50ns = '? {object}.isElectronIDAvailable("egmGsfElectronIDs:cutBasedElectronID-CSA14-50ns-V1-standalone-tight") ?{object}.electronID("egmGsfElectronIDs:cutBasedElectronID-CSA14-50ns-V1-standalone-tight") : {object}.userFloat("cutBasedElectronID-CSA14-50ns-V1-standalone-tight")',
+    objectCBIDCSA14_VETO_25ns = '? {object}.isElectronIDAvailable("egmGsfElectronIDs:cutBasedElectronID-CSA14-PU20bx25-V0-standalone-veto") ?{object}.electronID("egmGsfElectronIDs:cutBasedElectronID-CSA14-PU20bx25-V0-standalone-veto") : {object}.userFloat("cutBasedElectronID-CSA14-PU20bx25-V0-standalone-veto")',
+    objectCBIDCSA14_LOOSE_25ns = '? {object}.isElectronIDAvailable("egmGsfElectronIDs:cutBasedElectronID-CSA14-PU20bx25-V0-standalone-loose") ?{object}.electronID("egmGsfElectronIDs:cutBasedElectronID-CSA14-PU20bx25-V0-standalone-loose") : {object}.userFloat("cutBasedElectronID-CSA14-PU20bx25-V0-standalone-loose")',
+    objectCBIDCSA14_MEDIUM_25ns = '? {object}.isElectronIDAvailable("egmGsfElectronIDs:cutBasedElectronID-CSA14-PU20bx25-V0-standalone-medium") ?{object}.electronID("egmGsfElectronIDs:cutBasedElectronID-CSA14-PU20bx25-V0-standalone-medium") : {object}.userFloat("cutBasedElectronID-CSA14-PU20bx25-V0-standalone-medium")',
+    objectCBIDCSA14_TIGHT_25ns = '? {object}.isElectronIDAvailable("egmGsfElectronIDs:cutBasedElectronID-CSA14-PU20bx25-V0-standalone-tight") ?{object}.electronID("egmGsfElectronIDs:cutBasedElectronID-CSA14-PU20bx25-V0-standalone-tight") : {object}.userFloat("cutBasedElectronID-CSA14-PU20bx25-V0-standalone-tight")',
+
     # Use cms.string so we get the parentheses formatting bonus
     objectRelPFIsoDB = cms.string(
         "({object}.userIso(0)"
@@ -65,11 +76,6 @@ id = PSet(
     ##     "/{object}.pt()"
     ## ),
     
-    objectEffectiveArea2012Data = cms.string('{object}.userFloat("ea_comb_Data2012_iso04_kt6PFJ")'),
-    objectEffectiveArea2011Data = cms.string('{object}.userFloat("ea_comb_Data2011_iso04_kt6PFJ")'),
-    objectEffectiveAreaFall11MC = cms.string('{object}.userFloat("ea_comb_Fall11MC_iso04_kt6PFJ")'),
-    objectRhoHZG2011 = cms.string('{object}.userFloat("hzgRho2011")'),
-    objectRhoHZG2012 = cms.string('{object}.userFloat("hzgRho2012")'),
     objectRelIso = cms.string("({object}.dr03TkSumPt()"
                "+max({object}.dr03EcalRecHitSumEt()-1.0,0.0)"
                "+{object}.dr03HcalTowerSumEt())/{object}.pt()"),

--- a/NtupleTools/test/make_ntuples_cfg.py
+++ b/NtupleTools/test/make_ntuples_cfg.py
@@ -262,9 +262,22 @@ if options.rerunFSA:
         process.runNewElectronMVAID = cms.Path(process.runAndEmbedSummer13Id)
         process.schedule.append(process.runNewElectronMVAID)
 
+    # embed some things we need that arent in miniAOD yet (like some ids)
+    output_commands = []
+    if options.useMiniAOD:
+        process.miniPatElectrons = cms.EDProducer(
+            "MiniAODElectronIDEmbedder",
+            src=cms.InputTag(fs_daughter_inputs['electrons']),
+            MVAId=cms.InputTag("mvaTrigV0CSA14","","addMVAid")
+        )
+        output_commands.append('*_miniPatElectrons_*_*')
+        fs_daughter_inputs['electrons'] = "miniPatElectrons"
+        process.runMiniAODObjectEmbedding = cms.Path(process.miniPatElectrons)
+        process.schedule.append(process.runMiniAODObjectEmbedding)
+
     # Eventually, set buildFSAEvent to False, currently working around bug
     # in pat tuples.
-    produce_final_states(process, fs_daughter_inputs, [], process.buildFSASeq,
+    produce_final_states(process, fs_daughter_inputs, output_commands, process.buildFSASeq,
                          'puTagDoesntMatter', buildFSAEvent=True,
                          noTracks=True, noPhotons=options.noPhotons,
                          zzMode=options.zzMode, rochCor=options.rochCor,

--- a/PatTools/plugins/BuildFile.xml
+++ b/PatTools/plugins/BuildFile.xml
@@ -24,4 +24,6 @@
   <use   name="RecoEgamma/EgammaTools"/>
   
   <use   name="RecoBTag/SecondaryVertex"/>
+
+  <use   name="EgammaAnalysis/ElectronTools"/>
 </library>

--- a/PatTools/plugins/MiniAODElectronIDEmbedder.cc
+++ b/PatTools/plugins/MiniAODElectronIDEmbedder.cc
@@ -1,0 +1,103 @@
+/*
+ * Embeds the electron ID as recommended by EGamma POG (expected to be depreciated when IDs included by default).
+ * https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2
+ * https://twiki.cern.ch/twiki/bin/viewauth/CMS/MultivariateElectronIdentificationRun2
+ * https://twiki.cern.ch/twiki/bin/viewauth/CMS/HEEPElectronIdentificationRun2
+ * Author: Devin N. Taylor, UW-Madison
+ */
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+
+#include "DataFormats/Common/interface/ValueMap.h"
+
+#include "DataFormats/PatCandidates/interface/Electron.h"
+
+#include "EgammaAnalysis/ElectronTools/interface/EGammaMvaEleEstimatorCSA14.h"
+
+#include <math.h>
+
+// class declaration
+class MiniAODElectronIDEmbedder : public edm::EDProducer {
+  public:
+    explicit MiniAODElectronIDEmbedder(const edm::ParameterSet& pset);
+    virtual ~MiniAODElectronIDEmbedder(){}
+    void produce(edm::Event& evt, const edm::EventSetup& es);
+
+  private:
+    edm::EDGetTokenT<pat::ElectronCollection> electronsCollection_;
+    edm::InputTag MVAidCollection_;
+    EGammaMvaEleEstimatorCSA14* MVATrig_;
+};
+
+// class member functions
+MiniAODElectronIDEmbedder::MiniAODElectronIDEmbedder(const edm::ParameterSet& pset) {
+  electronsCollection_ = consumes<pat::ElectronCollection>(pset.getParameter<edm::InputTag>("src"));
+  MVAidCollection_     = pset.getParameter<edm::InputTag>("MVAId");
+
+  std::vector<std::string> myManualCatWeigths;
+  myManualCatWeigths.push_back("EgammaAnalysis/ElectronTools/data/CSA14/TrigIDMVA_EB_BDT.weights.xml");
+  myManualCatWeigths.push_back("EgammaAnalysis/ElectronTools/data/CSA14/TrigIDMVA_EE_BDT.weights.xml");
+  
+  vector<string> myManualCatWeigthsTrig;
+  string the_path;
+  for (unsigned i  = 0 ; i < myManualCatWeigths.size() ; i++){
+    the_path = edm::FileInPath ( myManualCatWeigths[i] ).fullPath();
+    myManualCatWeigthsTrig.push_back(the_path);
+  }
+  
+  MVATrig_ = new EGammaMvaEleEstimatorCSA14();
+  MVATrig_->initialize("BDT",
+                       EGammaMvaEleEstimatorCSA14::kTrig,
+                       true,
+                       myManualCatWeigthsTrig);
+
+  produces<pat::ElectronCollection>();
+}
+
+void MiniAODElectronIDEmbedder::produce(edm::Event& evt, const edm::EventSetup& es) {
+  edm::Handle<vector<pat::Electron>> electronsCollection;
+  evt.getByToken(electronsCollection_ , electronsCollection);
+
+  const vector<pat::Electron> * electrons = electronsCollection.product();
+
+  unsigned int nbElectron =  electrons->size();
+
+  std::auto_ptr<pat::ElectronCollection> output(new pat::ElectronCollection);
+  output->reserve(nbElectron);
+
+  for(unsigned i = 0 ; i < nbElectron; i++){
+    pat::Electron electron(electrons->at(i));
+
+    // mva
+    electron.addUserFloat("mvaTrigV0CSA14",MVATrig_->mvaValue(electrons->at(i),false));
+
+    // cutbased id TODO
+    electron.addUserFloat("cutBasedElectronID-CSA14-50ns-V1-standalone-veto",-1.);
+    electron.addUserFloat("cutBasedElectronID-CSA14-50ns-V1-standalone-loose",-1.);
+    electron.addUserFloat("cutBasedElectronID-CSA14-50ns-V1-standalone-medium",-1.);
+    electron.addUserFloat("cutBasedElectronID-CSA14-50ns-V1-standalone-tight",-1.);
+    electron.addUserFloat("cutBasedElectronID-CSA14-PU20bx25-V0-standalone-veto",-1.);
+    electron.addUserFloat("cutBasedElectronID-CSA14-PU20bx25-V0-standalone-loose",-1.);
+    electron.addUserFloat("cutBasedElectronID-CSA14-PU20bx25-V0-standalone-medium",-1.);
+    electron.addUserFloat("cutBasedElectronID-CSA14-PU20bx25-V0-standalone-tight",-1.);
+
+    output->push_back(electron);
+  }
+
+  evt.put(output);
+}
+
+// define plugin
+DEFINE_FWK_MODULE(MiniAODElectronIDEmbedder);

--- a/PatTools/python/patFinalStateProducers.py
+++ b/PatTools/python/patFinalStateProducers.py
@@ -195,8 +195,7 @@ def produce_final_states(process, collections, output_commands,
         src=cms.InputTag(jetsrc),
         # I leave it loose here, can be tightened at the last step
         preselection=cms.string(
-            "pt>20 & abs(eta) < 2.5 & "
-            "userFloat('idLoose')"),
+            "pt>20 & abs(eta) < 2.5"),
                 # & userInt('fullIdLoose')"),
         # overlap checking configurables
         checkOverlaps=cms.PSet(
@@ -216,7 +215,7 @@ def produce_final_states(process, collections, output_commands,
                 src=cms.InputTag("electronsForFinalStates"),
                 algorithm=cms.string("byDeltaR"),
                 preselection=cms.string(
-                    "pt>10&&userFloat('wp95')>0"
+                    "pt>10"
                     "&&(userIso(0)+max(userIso(1)+neutralHadronIso()"
                     "-0.5*userIso(2),0.0))/pt()<0.3"),
                 deltaR=cms.double(0.3),

--- a/recipe/recipe_13TeV.sh
+++ b/recipe/recipe_13TeV.sh
@@ -47,6 +47,9 @@ then
 #     git cms-merge-topic -u cms-tau-pog:CMSSW_7_1_X_taus  
 #   fi  
 
+  echo "Checking out EGamma MVA ID for miniAOD"
+  git cms-merge-topic HuguesBrun:addTheElecIDMVAoutputCSA14 #needed until mva added by default
+
   echo "Checking out EGamma POG recipe for electron corrections"
   #Following Volker's instructions
   #git cms-cvs-history import V09-00-01 RecoEgamma/EgammaTools


### PR DESCRIPTION
Allows filling of miniAOD final states that include jets (removed the electron cleaning loose working point-can't add back in just yet since cutbased IDs are not ready for miniAOD electrons, just mva). Also adding the miniAOD electron mva estimator as a userfloat. Eventually this should be in the miniAOD format and the producer can be removed and the value accessed via the electronID method.
Also added space for the cut based IDs. The values are defined, so we could potentially calculate them manually at this point.
