### PR TITLE
Updating submission script to avoid datadefs

### DIFF
--- a/NtupleTools/test/README.rst
+++ b/NtupleTools/test/README.rst
@@ -55,11 +55,15 @@ on the 2012-03-05-EWKPatTuple::
 miniAOD Example
 ---------------
 
-The following will run a bunch of CSA14 miniAOD files desired for the H->ZZ->4l analysis. Remote files can be run over condor using xrootd (the MiniAOD samples are not at UW). 
+The following will run a bunch of PHYS14 miniAOD files. As new MiniAOD versions are released,
+you only need to change the campaign-tag. This command uses a DAS lookup to find all available
+datasets for a given campaign and pattern match to the DAS name desired. Careful selection of 
+the campaign tag should avoid repeated datasets (since old datasets should be invalidated as
+the new ones arrive: example, *-v1 should not appear if *-v2 has been released). Most other
+things are now taken care of without special options (miniaod 25ns has been made default)::
 
-   submit_job.py MAKE_ZZ_NTUPLES_FSR_PU20BX25_1 $fsa/NtupleTools/test/make_ntuples_cfg.py channels="zz" useMiniAOD=1 isMC=1 rerunFSA=1 use25ns=1 hzzfsr=1 --tuple-dbs=$fsa/MetaData/tuples/MiniAOD-13TeV.json --xrootd --input-files-per-job=1 --samples "TTjets-PU20bx25" "Zjets_M50-PU20bx25" "WZTo3LNu-PU20bx25" "ggHZZ-PU20bx25" "VBFHZZ-PU20bx25" "ZZTo4L-PU20bx25" > HZZ4l_FSR_ntuples_PU20bx25_1.sh
-
-   bash HZZ4l_FSR_nuples_PU20bx25_1.sh
+   submit_job.py MiniAOD_Test make_ntuples_cfg.py channels="eeee,eeem,eemm,emmm,mmmm,eee,eem,emm,mmm" --campaign-tag="Phys14DR-PU20bx25_PHYS14_25_V*" --samples "ZZTo4L*" "WZJetsTo3LNu*" "WJetsToLNu_13TeV*" "T*_tW*" "T*ToLeptons_*" "TTW*" "TTZ*" "TTJets_MSDecaysCKM*" "DYJetsToLL_M-50_13TeV*" > do_test.sh 
+   bash < do_test.sh
 
 
 

--- a/NtupleTools/test/make_ntuples_cfg.py
+++ b/NtupleTools/test/make_ntuples_cfg.py
@@ -37,8 +37,8 @@ svFit=1 - run the SVfit on appropriate pairs
 rerunQGJetID=0 - rerun the quark-gluon JetID
 runNewElectronMVAID=0 - run the new electron MVAID
 rerunJets=0   - rerun with new jet energy corrections
-useMiniAOD=0 - run on miniAOD rather than UW PATTuples
-use25ns=0 - run on 25 ns miniAOD (50 ns default)
+useMiniAOD=1 - run on miniAOD rather than UW PATTuples (default)
+use25ns=1 - run on 25 ns miniAOD (default, 0 = 50ns)
 runDQM=0 - run over single object final states to test all object properties (wont check diobject properties)
 hzzfsr=0 - Include FSR contribution a la HZZ4l group
 
@@ -82,8 +82,8 @@ options = TauVarParsing.TauVarParsing(
     dblhMode=False, # For double-charged Higgs analysis
     runTauSpinner=0,
     GlobalTag="",
-    useMiniAOD=0,
-    use25ns=0,
+    useMiniAOD=1,
+    use25ns=1,
     runDQM=0,
     hzzfsr=0,
 )

--- a/Utilities/scripts/submit_job.py
+++ b/Utilities/scripts/submit_job.py
@@ -72,6 +72,13 @@ if __name__ == "__main__":
         ' Generally kept in MetaData/tuples'
     )
 
+    input_group.add_argument(
+        '--campaign-tag', dest='campaignstring',
+        help = 'DAS production campaign string for query.'
+               ' For a given DAS query, it is the second part'
+               ' (dataset=/*/[campaign-tag]/MINIAODSIM).'
+    )
+
     filter_group = parser.add_argument_group('Sample Filters')
     filter_group.add_argument('--analysis', type=str, default='',
                               help='Which analysis to use - this determines'
@@ -121,150 +128,245 @@ if __name__ == "__main__":
     sys.stdout.write('# The command was: %s\n' % ' '.join(sys.argv))
 
     sys.stdout.write('export TERMCAP=screen\n')
-    for sample, sample_info in reversed(
-        sorted(datadefs.iteritems(), key=lambda (x,y): x)):
-        passes_filter = True
-        # Filter by analysis
-        if args.analysis:
-            passes_ana = sample_info['analysis'] == args.analysis
-            passes_filter = passes_filter and passes_ana
-        # Filter by sample wildcards
-        if args.samples:
-            passes_wildcard = False
-            for pattern in args.samples:
-                if fnmatch.fnmatchcase(sample, pattern):
-                    passes_wildcard = True
-            passes_filter = passes_wildcard and passes_filter
-        if not passes_filter:
-            continue
 
-        submit_dir = args.subdir.format(
-            user = os.environ['LOGNAME'],
-            jobid = args.jobid,
-            sample = sample
-        )
-        if os.path.exists(submit_dir):
-            sys.stdout.write('# Submission directory for %s already exists\n'
-                            % sample)
-            log.warning("Submit directory for sample %s exists, skipping",
-                       sample)
-            continue
-
-        log.info("Building submit files for sample %s", sample)
-
-        dag_dir = args.dagdir.format(
-            user = os.environ['LOGNAME'],
-            jobid = args.jobid,
-            sample = sample
-        )
-
-        output_dir = args.outdir.format(
-            user = os.environ['LOGNAME'],
-            jobid = args.jobid,
-            sample = sample
-        )
-
-        input_commands = []
-
-        if args.inputdir:
-            input_dir = args.inputdir.format(
+    # first, make DAS query for dataset if not using local dataset or hdfs/dbs tuple list
+    if args.campaignstring:
+        dbs_datasets = get_das_info('/*/%s/MINIAOD*' % args.campaignstring)
+        # check sample wildcards
+        for dataset in dbs_datasets:
+            dataset_name = dataset.split('/')[1] 
+            passes_filter = True
+            if args.samples:
+                passes_wildcard = False
+                for pattern in args.samples:
+                    if fnmatch.fnmatchcase(dataset_name, pattern):
+                        passes_wildcard = True
+                passes_filter = passes_wildcard and passes_filter
+            if not passes_filter:
+                continue
+            
+            submit_dir = args.subdir.format(
                 user = os.environ['LOGNAME'],
                 jobid = args.jobid,
-                sample = sample,
-                dataset = sample_info['datasetpath'],
-                myhdfs = 'root://cmsxrootd.hep.wisc.edu//store/user/%s/' % os.environ['LOGNAME']
+                sample = dataset_name
             )
-            input_commands.append('"--input-dir=%s"' % input_dir)
-            if args.cleancrab:
-                input_commands.append('--clean-crab-dupes')
-        elif args.tuplelist:
-            with open(args.tuplelist) as tuple_file:
-                # Parse info about PAT tuples
-                tuple_info = json.load(tuple_file)
-                # Find the matching pat tuple DBS name
-                #import pdb; pdb.set_trace();
-                matching_datasets = []
-                for pat_tuple, pat_tuple_info in tuple_info.iteritems():
-                    if sample in pat_tuple:
-                        matching_datasets.append(pat_tuple)
-                if len(matching_datasets) != 1:
-                    log.error("No or multiple matching datasets found "
-                              " for sample %s, matches: [%s]",
-                              sample, ", ".join(matching_datasets))
-                    continue
-                datasetpath = tuple_info[matching_datasets[0]]
+            if os.path.exists(submit_dir):
+                sys.stdout.write('# Submission directory for %s already exists\n'
+                                % dataset_name)
+                log.warning("Submit directory for sample %s exists, skipping",
+                           dataset_name)
+                continue
 
-                if args.xrootd:
-                    files = get_das_info('file dataset=%s' % datasetpath)
-                    mkdir_cmd = "mkdir -p %s" % (dag_dir+"inputs")
-                    os.system(mkdir_cmd)
-                    input_txt = '%s_inputfiles.txt' % matching_datasets[0]
-                    input_txt_path = os.path.join(dag_dir+"inputs", input_txt)
-                    with open(input_txt_path, 'w') as txt:
-                        txt.write('\n'.join(files))
-                    input_commands.extend([
-                        '--input-file-list=%s' % input_txt_path,
-                        '--assume-input-files-exist', 
-                        '--input-dir=root://xrootd.unl.edu/',
-                    ])
-                else:
-                    input_commands.append(
-                        '--input-dbs-path=%s' % datasetpath)
-                    input_commands.append(
-                        '--dbs-service-url=http://cmsdbsprod.cern.ch/cms_dbs_ph_analysis_01/servlet/DBSServlet')
-        elif args.tupledirlist:
-            with open(args.tupledirlist) as tuple_file:
-                # Parse info about PAT tuples
-                tuple_info = json.load(tuple_file)
-                if sample not in tuple_info:
-                    log.warning("No data directory for %s specified, skipping",
-                                sample)
-                    continue
-                input_dir = tuple_info[sample]
-                if '!' in input_dir:
-                    # ! means it a DBS path
-                    input_commands.append(
-                        '--dbs-service-url=http://cmsdbsprod.cern.ch/cms_dbs_ph_analysis_01/servlet/DBSServlet'
-                    )
-                    input_commands.append(
-                        '--input-dbs-path=%s' % input_dir.replace('!', ''))
-                else:
-                    input_commands.append('"--input-dir=%s"' % input_dir)
-                    if args.cleancrab:
-                        input_commands.append('--clean-crab-dupes')
+            log.info("Building submit files for sample %s", dataset_name)
 
-        command = [
-            'farmoutAnalysisJobs',
-            '--infer-cmssw-path',
-            '"--submit-dir=%s"' % submit_dir,
-            '"--output-dag-file=%s"' % dag_dir,
-            '"--output-dir=%s"' % output_dir,
-            '--input-files-per-job=%i' % args.filesperjob,
-        ]
-        if args.sharedfs:
-            command.append('--shared-fs')
-        command.extend(input_commands)
-        command.extend([
-            # The job ID
-            '%s-%s' % (args.jobid, sample),
-            args.cfg
-        ])
+            dag_dir = args.dagdir.format(
+                user = os.environ['LOGNAME'],
+                jobid = args.jobid,
+                sample = dataset_name
+            )
 
-        command.extend(args.cmsargs)
-        command.append("'inputFiles=$inputFileNames'")
-        command.append("'outputFile=$outputFileName'")
+            output_dir = args.outdir.format(
+                user = os.environ['LOGNAME'],
+                jobid = args.jobid,
+                sample = dataset_name
+            )
 
-        if args.apply_cms_lumimask and 'lumi_mask' in sample_info:
-            lumi_mask_path = os.path.join(
-                os.environ['CMSSW_BASE'], 'src', sample_info['lumi_mask'])
-            command.append('lumiMask=%s' % lumi_mask_path)
-            firstRun = sample_info.get('firstRun', -1)
-            if firstRun > 0:
-                command.append('firstRun=%i' % firstRun)
-            lastRun = sample_info.get('lastRun', -1)
-            if lastRun > 0:
-                command.append('lastRun=%i' % lastRun)
+            input_commands = []
 
-        sys.stdout.write('# Submit file for sample %s\n' % sample)
-        sys.stdout.write('mkdir -p %s\n' % os.path.dirname(dag_dir))
-        sys.stdout.write(' '.join(command) + '\n')
+            files = get_das_info('file dataset=%s' % dataset)
+            mkdir_cmd = "mkdir -p %s" % (dag_dir+"inputs")
+            os.system(mkdir_cmd)
+            input_txt = '%s_inputfiles.txt' % dataset_name
+            input_txt_path = os.path.join(dag_dir+"inputs", input_txt)
+            with open(input_txt_path, 'w') as txt:
+                txt.write('\n'.join(files))
+            input_commands.extend([
+                '--input-file-list=%s' % input_txt_path,
+                '--assume-input-files-exist', 
+                '--input-dir=root://xrootd.unl.edu/',
+            ])
+
+            command = [
+                'farmoutAnalysisJobs',
+                '--infer-cmssw-path',
+                '"--submit-dir=%s"' % submit_dir,
+                '"--output-dag-file=%s"' % dag_dir,
+                '"--output-dir=%s"' % output_dir,
+                '--input-files-per-job=%i' % args.filesperjob,
+            ]
+            if args.sharedfs:
+                command.append('--shared-fs')
+            command.extend(input_commands)
+            command.extend([
+                # The job ID
+                '%s-%s' % (args.jobid, dataset_name),
+                args.cfg
+            ])
+
+            command.extend(args.cmsargs)
+            command.append("'inputFiles=$inputFileNames'")
+            command.append("'outputFile=$outputFileName'")
+
+            if args.apply_cms_lumimask and 'lumi_mask' in sample_info:
+                lumi_mask_path = os.path.join(
+                    os.environ['CMSSW_BASE'], 'src', sample_info['lumi_mask'])
+                command.append('lumiMask=%s' % lumi_mask_path)
+                firstRun = sample_info.get('firstRun', -1)
+                if firstRun > 0:
+                    command.append('firstRun=%i' % firstRun)
+                lastRun = sample_info.get('lastRun', -1)
+                if lastRun > 0:
+                    command.append('lastRun=%i' % lastRun)
+
+            sys.stdout.write('# Submit file for sample %s\n' % dataset_name)
+            sys.stdout.write('mkdir -p %s\n' % os.path.dirname(dag_dir))
+            sys.stdout.write(' '.join(command) + '\n')
+    else:
+        # this is the old version that uses datadefs
+        for sample, sample_info in reversed(
+            sorted(datadefs.iteritems(), key=lambda (x,y): x)):
+            passes_filter = True
+            # Filter by analysis
+            if args.analysis:
+                passes_ana = sample_info['analysis'] == args.analysis
+                passes_filter = passes_filter and passes_ana
+            # Filter by sample wildcards
+            if args.samples:
+                passes_wildcard = False
+                for pattern in args.samples:
+                    if fnmatch.fnmatchcase(sample, pattern):
+                        passes_wildcard = True
+                passes_filter = passes_wildcard and passes_filter
+            if not passes_filter:
+                continue
+
+            submit_dir = args.subdir.format(
+                user = os.environ['LOGNAME'],
+                jobid = args.jobid,
+                sample = sample
+            )
+            if os.path.exists(submit_dir):
+                sys.stdout.write('# Submission directory for %s already exists\n'
+                                % sample)
+                log.warning("Submit directory for sample %s exists, skipping",
+                           sample)
+                continue
+
+            log.info("Building submit files for sample %s", sample)
+
+            dag_dir = args.dagdir.format(
+                user = os.environ['LOGNAME'],
+                jobid = args.jobid,
+                sample = sample
+            )
+
+            output_dir = args.outdir.format(
+                user = os.environ['LOGNAME'],
+                jobid = args.jobid,
+                sample = sample
+            )
+
+            input_commands = []
+
+            if args.inputdir:
+                input_dir = args.inputdir.format(
+                    user = os.environ['LOGNAME'],
+                    jobid = args.jobid,
+                    sample = sample,
+                    dataset = sample_info['datasetpath'],
+                    myhdfs = 'root://cmsxrootd.hep.wisc.edu//store/user/%s/' % os.environ['LOGNAME']
+                )
+                input_commands.append('"--input-dir=%s"' % input_dir)
+                if args.cleancrab:
+                    input_commands.append('--clean-crab-dupes')
+            elif args.tuplelist:
+                with open(args.tuplelist) as tuple_file:
+                    # Parse info about PAT tuples
+                    tuple_info = json.load(tuple_file)
+                    # Find the matching pat tuple DBS name
+                    #import pdb; pdb.set_trace();
+                    matching_datasets = []
+                    for pat_tuple, pat_tuple_info in tuple_info.iteritems():
+                        if sample in pat_tuple:
+                            matching_datasets.append(pat_tuple)
+                    if len(matching_datasets) != 1:
+                        log.error("No or multiple matching datasets found "
+                                  " for sample %s, matches: [%s]",
+                                  sample, ", ".join(matching_datasets))
+                        continue
+                    datasetpath = tuple_info[matching_datasets[0]]
+
+                    if args.xrootd:
+                        files = get_das_info('file dataset=%s' % datasetpath)
+                        mkdir_cmd = "mkdir -p %s" % (dag_dir+"inputs")
+                        os.system(mkdir_cmd)
+                        input_txt = '%s_inputfiles.txt' % matching_datasets[0]
+                        input_txt_path = os.path.join(dag_dir+"inputs", input_txt)
+                        with open(input_txt_path, 'w') as txt:
+                            txt.write('\n'.join(files))
+                        input_commands.extend([
+                            '--input-file-list=%s' % input_txt_path,
+                            '--assume-input-files-exist', 
+                            '--input-dir=root://xrootd.unl.edu/',
+                        ])
+                    else:
+                        input_commands.append(
+                            '--input-dbs-path=%s' % datasetpath)
+                        input_commands.append(
+                            '--dbs-service-url=http://cmsdbsprod.cern.ch/cms_dbs_ph_analysis_01/servlet/DBSServlet')
+            elif args.tupledirlist:
+                with open(args.tupledirlist) as tuple_file:
+                    # Parse info about PAT tuples
+                    tuple_info = json.load(tuple_file)
+                    if sample not in tuple_info:
+                        log.warning("No data directory for %s specified, skipping",
+                                    sample)
+                        continue
+                    input_dir = tuple_info[sample]
+                    if '!' in input_dir:
+                        # ! means it a DBS path
+                        input_commands.append(
+                            '--dbs-service-url=http://cmsdbsprod.cern.ch/cms_dbs_ph_analysis_01/servlet/DBSServlet'
+                        )
+                        input_commands.append(
+                            '--input-dbs-path=%s' % input_dir.replace('!', ''))
+                    else:
+                        input_commands.append('"--input-dir=%s"' % input_dir)
+                        if args.cleancrab:
+                            input_commands.append('--clean-crab-dupes')
+
+            command = [
+                'farmoutAnalysisJobs',
+                '--infer-cmssw-path',
+                '"--submit-dir=%s"' % submit_dir,
+                '"--output-dag-file=%s"' % dag_dir,
+                '"--output-dir=%s"' % output_dir,
+                '--input-files-per-job=%i' % args.filesperjob,
+            ]
+            if args.sharedfs:
+                command.append('--shared-fs')
+            command.extend(input_commands)
+            command.extend([
+                # The job ID
+                '%s-%s' % (args.jobid, sample),
+                args.cfg
+            ])
+
+            command.extend(args.cmsargs)
+            command.append("'inputFiles=$inputFileNames'")
+            command.append("'outputFile=$outputFileName'")
+
+            if args.apply_cms_lumimask and 'lumi_mask' in sample_info:
+                lumi_mask_path = os.path.join(
+                    os.environ['CMSSW_BASE'], 'src', sample_info['lumi_mask'])
+                command.append('lumiMask=%s' % lumi_mask_path)
+                firstRun = sample_info.get('firstRun', -1)
+                if firstRun > 0:
+                    command.append('firstRun=%i' % firstRun)
+                lastRun = sample_info.get('lastRun', -1)
+                if lastRun > 0:
+                    command.append('lastRun=%i' % lastRun)
+
+            sys.stdout.write('# Submit file for sample %s\n' % sample)
+            sys.stdout.write('mkdir -p %s\n' % os.path.dirname(dag_dir))
+            sys.stdout.write(' '.join(command) + '\n')


### PR DESCRIPTION
@nwoods @dabelknap @mcepeda 

This PR does two things. First, updates the make_ntuples defaults to miniAOD and 25ns (since this miniAOD_dev is never going to run over PATTuples).

Second, it updates the submit_jobs script to run entirely through DAS queries rather than using the datadefs in the MetaData directory. I've left that stuff in for now, but at some point we can probably clean it all up if we agree that this is a better method. I don't remember what else uses the datadefs in the other parts of FSA.

Anyway, how to use the new submit_jobs.py:
```
submit_job.py MiniAOD_Test make_ntuples_cfg.py channels="eeee,eeem,eemm,emmm,mmmm,eee,eem,emm,mmm" --campaign-tag="Phys14DR-PU20bx25_PHYS14_25_V*" --samples "ZZTo4L*" "WZJetsTo3LNu*" "WJetsToLNu_13TeV*" "T*_tW*" "T*ToLeptons_*" "TTW*" "TTZ*" "TTJets_MSDecaysCKM*" "DYJetsToLL_M-50_13TeV*" > do_test.sh
bash < do_test.sh
```
The major advantage is that you can just run new ntuples by changing the campaign-tag option rather than going through and updating all of the MiniAOD-13TeV.json and data13TeV.py files. This will also avoid the issue of people constantly changing the datadefs in their own PRs and overwriting something someone else needs for their analysis.

Also, by default runs using xrootd since that is where the world is heading.

You do have to be careful about the names of samples since there are now 100's of datasets returned via the DAS query rather than the ~50 we had in the .json files.