### PR TITLE
Fixed bug due to python shadowing of struct.py in Utilities

### DIFF
--- a/PlotTools/python/Plotter.py
+++ b/PlotTools/python/Plotter.py
@@ -13,7 +13,7 @@ import rootpy.plotting.views as views
 import rootpy.plotting as plotting
 from FinalStateAnalysis.MetaData.data_views import data_views
 from FinalStateAnalysis.PlotTools.RebinView import RebinView
-from FinalStateAnalysis.Utilities.struct import struct
+from FinalStateAnalysis.Utilities.struct import FSAstruct as struct
 import FinalStateAnalysis.Utilities.prettyjson as prettyjson
 import ROOT
 

--- a/StatTools/scripts/compare_limit.py
+++ b/StatTools/scripts/compare_limit.py
@@ -5,7 +5,7 @@ Simple script that compares multiple limits
 
 import rootpy.io as io
 import itertools
-from FinalStateAnalysis.Utilities.struct import struct
+from FinalStateAnalysis.Utilities.struct import FSAstruct as struct
 from FinalStateAnalysis.Utilities.solarized import colors
 import FinalStateAnalysis.Utilities.prettyjson as prettyjson
 from rootpy.plotting.graph import Graph

--- a/StatTools/scripts/fit_efficiency2D.py
+++ b/StatTools/scripts/fit_efficiency2D.py
@@ -14,7 +14,7 @@ Where [efficiency] is a RooFit factory command.
 import array
 from RecoLuminosity.LumiDB import argparse
 from FinalStateAnalysis.PlotTools.RebinView import RebinView
-from FinalStateAnalysis.Utilities.struct import struct
+from FinalStateAnalysis.Utilities.struct import FSAstruct as struct
 import rootpy.plotting as plotting
 import logging
 import sys

--- a/StatTools/scripts/plot_limit.py
+++ b/StatTools/scripts/plot_limit.py
@@ -4,7 +4,7 @@ Simple script that takes as input one or more json files and produces a limit pl
 '''
 
 import rootpy.io as io
-from FinalStateAnalysis.Utilities.struct import struct
+from FinalStateAnalysis.Utilities.struct import FSAstruct as struct
 from FinalStateAnalysis.Utilities.solarized import colors
 import FinalStateAnalysis.Utilities.prettyjson as prettyjson
 from rootpy.plotting.graph import Graph

--- a/Utilities/python/FSAstruct.py
+++ b/Utilities/python/FSAstruct.py
@@ -2,7 +2,7 @@
 python dict - to class
 copyed from: http://stackoverflow.com/questions/1305532/convert-python-dict-to-object 
 '''
-class struct:
+class FSAstruct:
     def __init__(self, **entries): 
         self.__dict__.update(entries)
 


### PR DESCRIPTION
Bug symptom:

```
$ cd PatTools/test
$ python submit_tuplization.py asdf --xrootd --dbsnames=blah > file.sh
$ cat file.sh
...
version.py - exception caught and discarded
Unexpected error: <type 'exceptions.IndexError'>
...
```

In [version.py](https://github.com/uwcms/FinalStateAnalysis/blob/master/Utilities/python/version.py), used by [submit_tuplization.py](https://github.com/uwcms/FinalStateAnalysis/blob/master/PatTools/test/submit_tuplization.py#L168) there is a usage of a standard python struct, which gets shadowed by the `struct.py` in the same directory as `version.py`, causing the above error.

Fix: `grep -r 'import struct' . -l |xargs sed -i 's/import struct/import FSAstruct as struct/'`
