### PR TITLE
Updated PAT locations for 8TeV analyses

### DIFF
--- a/MetaData/python/data8TeV.py
+++ b/MetaData/python/data8TeV.py
@@ -62,6 +62,22 @@ datadefs = {
          # https://twiki.cern.ch/twiki/bin/viewauth/CMS/StandardModelCrossSectionsat8TeV
          'x_sec': 3503.71,
      },
+    'Zjets_lowMass' : {
+         'analyses': [''],
+         'datasetpath': '/DYJetsToLL_M-10To50filter_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM',
+         'pu': 'S10',
+         'calibrationTarget': 'Summer12',
+         # AN2012-123
+         'x_sec': 860.5,
+     },
+     'WGToLNuG' : {
+        'analyses': [''],
+        'datasetpath': '/WGToLNuG_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM',
+        'pu': 'S10',
+        'calibrationTarget': 'Summer12',
+        # AN2012-123
+        'xsec': 461.6,
+    },
     'Z2jets_M50' : {
         'analyses': ['HTT'],
         'datasetpath': '/DY2JetsToLL_M-50_TuneZ2Star_8TeV-madgraph/Summer12-PU_S7_START52_V9-v1/AODSIM',
@@ -96,7 +112,24 @@ datadefs = {
    'datasetpath': '/ZZJetsTo2L2Nu_TuneZ2star_8TeV-madgraph-tauola/Summer12-PU_S7_START52_V9-v3/AODSIM',
    'pu': 'S7',
    'calibrationTarget': 'Summer12',
-   'xsec': -999,
+   # AN2012-123
+   'xsec': 0.380,
+       },
+     'ZG_Inclusive' : {
+   'analyses': [''],
+   'datasetpath': '/ZG_Inclusive_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM',
+   'pu': 'S10',
+   'calibrationTarget': 'Summer12',
+   # AN2012-123
+   'xsec': 123.9,
+       },
+    'ZH_ZToLL_HToInv_M-125' : {
+   'analyses': [''],
+   'datasetpath': '/ZH_ZToLL_HToInv_M-125_8TeV-pythia6/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM',
+   'pu': 'S10',
+   'calibrationTarget': 'Summer12',
+   # AN2012-123
+   'xsec': 0.0398,
        },
     'ZZJetsTo2L2Q_TuneZ2' : {
    'analyses': ['HTT'],

--- a/MetaData/tuples/PATTuples-8TeV.json
+++ b/MetaData/tuples/PATTuples-8TeV.json
@@ -75,11 +75,11 @@
     "WWZNoGstarJets" : "/hdfs/store/user/dntaylor/WWZNoGstarJets_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/Fall2014_v1",
     "ZZZNoGstarJets" : "/hdfs/store/user/dntaylor/ZZZNoGstarJets_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/Fall2014_v1",
 
-    "VH_H2Tau_M-125_PavelSync" : "/hdfs/store/user/stephane/Pavel_sync_07-16-2013-patTuple_cfg"
+    "VH_H2Tau_M-125_PavelSync" : "/hdfs/store/user/stephane/Pavel_sync_07-16-2013-patTuple_cfg",
 
-    "DYJetsToLL_M-10To50filter_8TeV-madgraph" : "/store/user/nsmith/DYJetsToLL_M-10To50filter_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015"
-    "WGToLNuG_TuneZ2star_8TeV-madgraph-tauola" : "/store/user/nsmith/WGToLNuG_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015"
-    "ZG_Inclusive_8TeV-madgraph" : "/store/user/nsmith/ZG_Inclusive_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015"
-    "ZH_ZToLL_HToInv_M-125_8TeV-pythia6" : "/store/user/nsmith/ZH_ZToLL_HToInv_M-125_8TeV-pythia6/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015"
+    "DYJetsToLL_M-10To50filter_8TeV-madgraph" : "/store/user/nsmith/DYJetsToLL_M-10To50filter_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015",
+    "WGToLNuG_TuneZ2star_8TeV-madgraph-tauola" : "/store/user/nsmith/WGToLNuG_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015",
+    "ZG_Inclusive_8TeV-madgraph" : "/store/user/nsmith/ZG_Inclusive_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015",
+    "ZH_ZToLL_HToInv_M-125_8TeV-pythia6" : "/store/user/nsmith/ZH_ZToLL_HToInv_M-125_8TeV-pythia6/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015",
     "ZZJetsTo2L2Nu_TuneZ2star_8TeV-madgraph-tauola" : "/store/user/nsmith/ZZJetsTo2L2Nu_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V7A-v3/AODSIM/ZHinv2015"
 }

--- a/MetaData/tuples/PATTuples-8TeV.json
+++ b/MetaData/tuples/PATTuples-8TeV.json
@@ -77,9 +77,10 @@
 
     "VH_H2Tau_M-125_PavelSync" : "/hdfs/store/user/stephane/Pavel_sync_07-16-2013-patTuple_cfg",
 
-    "DYJetsToLL_M-10To50filter_8TeV-madgraph" : "/store/user/nsmith/DYJetsToLL_M-10To50filter_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015",
-    "WGToLNuG_TuneZ2star_8TeV-madgraph-tauola" : "/store/user/nsmith/WGToLNuG_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015",
-    "ZG_Inclusive_8TeV-madgraph" : "/store/user/nsmith/ZG_Inclusive_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015",
-    "ZH_ZToLL_HToInv_M-125_8TeV-pythia6" : "/store/user/nsmith/ZH_ZToLL_HToInv_M-125_8TeV-pythia6/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015",
-    "ZZJetsTo2L2Nu_TuneZ2star_8TeV-madgraph-tauola" : "/store/user/nsmith/ZZJetsTo2L2Nu_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V7A-v3/AODSIM/ZHinv2015"
+    "ZZJetsTo2L2Nu_TuneZ2star_8TeV-madgraph-tauola" : "/hdfs/store/user/nsmith/ZZJetsTo2L2Nu_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V7A-v3/AODSIM/ZHinv2015",
+    "ZG_Inclusive" : "/hdfs/store/user/nsmith/ZG_Inclusive_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015",
+    "ZH_ZToLL_HToInv_M-125" : "/hdfs/store/user/nsmith/ZH_ZToLL_HToInv_M-125_8TeV-pythia6/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015",
+    "WGToLNuG" : "/hdfs/store/user/nsmith/WGToLNuG_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015",
+    "Zjets_lowMass" : "/hdfs/store/user/nsmith/DYJetsToLL_M-10To50filter_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015",
+    "DYJetsToLL_M-10To50filter_8TeV-madgraph" : "/hdfs/store/user/nsmith/DYJetsToLL_M-10To50filter_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015"
 }

--- a/MetaData/tuples/PATTuples-8TeV.json
+++ b/MetaData/tuples/PATTuples-8TeV.json
@@ -76,4 +76,10 @@
     "ZZZNoGstarJets" : "/hdfs/store/user/dntaylor/ZZZNoGstarJets_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/Fall2014_v1",
 
     "VH_H2Tau_M-125_PavelSync" : "/hdfs/store/user/stephane/Pavel_sync_07-16-2013-patTuple_cfg"
+
+    'DYJetsToLL_M-10To50filter_8TeV-madgraph' : '/store/user/nsmith/DYJetsToLL_M-10To50filter_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015'
+    'WGToLNuG_TuneZ2star_8TeV-madgraph-tauola' : '/store/user/nsmith/WGToLNuG_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015'
+    'ZG_Inclusive_8TeV-madgraph' : '/store/user/nsmith/ZG_Inclusive_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015'
+    'ZH_ZToLL_HToInv_M-125_8TeV-pythia6' : '/store/user/nsmith/ZH_ZToLL_HToInv_M-125_8TeV-pythia6/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015'
+    'ZZJetsTo2L2Nu_TuneZ2star_8TeV-madgraph-tauola' : '/store/user/nsmith/ZZJetsTo2L2Nu_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V7A-v3/AODSIM/ZHinv2015'
 }

--- a/MetaData/tuples/PATTuples-8TeV.json
+++ b/MetaData/tuples/PATTuples-8TeV.json
@@ -77,9 +77,9 @@
 
     "VH_H2Tau_M-125_PavelSync" : "/hdfs/store/user/stephane/Pavel_sync_07-16-2013-patTuple_cfg"
 
-    'DYJetsToLL_M-10To50filter_8TeV-madgraph' : '/store/user/nsmith/DYJetsToLL_M-10To50filter_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015'
-    'WGToLNuG_TuneZ2star_8TeV-madgraph-tauola' : '/store/user/nsmith/WGToLNuG_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015'
-    'ZG_Inclusive_8TeV-madgraph' : '/store/user/nsmith/ZG_Inclusive_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015'
-    'ZH_ZToLL_HToInv_M-125_8TeV-pythia6' : '/store/user/nsmith/ZH_ZToLL_HToInv_M-125_8TeV-pythia6/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015'
-    'ZZJetsTo2L2Nu_TuneZ2star_8TeV-madgraph-tauola' : '/store/user/nsmith/ZZJetsTo2L2Nu_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V7A-v3/AODSIM/ZHinv2015'
+    "DYJetsToLL_M-10To50filter_8TeV-madgraph" : "/store/user/nsmith/DYJetsToLL_M-10To50filter_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015"
+    "WGToLNuG_TuneZ2star_8TeV-madgraph-tauola" : "/store/user/nsmith/WGToLNuG_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015"
+    "ZG_Inclusive_8TeV-madgraph" : "/store/user/nsmith/ZG_Inclusive_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015"
+    "ZH_ZToLL_HToInv_M-125_8TeV-pythia6" : "/store/user/nsmith/ZH_ZToLL_HToInv_M-125_8TeV-pythia6/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/ZHinv2015"
+    "ZZJetsTo2L2Nu_TuneZ2star_8TeV-madgraph-tauola" : "/store/user/nsmith/ZZJetsTo2L2Nu_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V7A-v3/AODSIM/ZHinv2015"
 }

--- a/MetaData/tuples/findUserTuples.py
+++ b/MetaData/tuples/findUserTuples.py
@@ -1,5 +1,8 @@
-from FinalStateAnalysis.MetaData.datadefs import datadefs
+#!/bin/env python
+import sys
 import subprocess
+import json
+from FinalStateAnalysis.MetaData.datadefs import datadefs
 
 def getUserHDFSlisting ( username ) :
   cmd = ['hdfs dfs']
@@ -15,12 +18,37 @@ def getUserHDFSlisting ( username ) :
       dir_subset.append(dirs[i])
   return dir_subset
 
-store_user = getUserHDFSlisting('nsmith')
-json_lines = []
-for name, datadef in datadefs.iteritems() :
-  if 'datasetpath' in datadef :
-    for dir in store_user :
-      if datadef['datasetpath'] in dir :
-        json_lines.append('    "%s" : "%s"' % (name, '/hdfs'+dir) )
+def findUserPatConfigJsonFiles ( username ) :
+  user_pat_configs = []
+  with subprocess.Popen("./scrape_pat_config.sh "+username, shell=True, stdout=subprocess.PIPE).stdout as user_pat_configs_filelist :
+    for file in user_pat_configs_filelist :
+      fn = file.strip()
+      # dict is wrapped by hash but hash is in dict...
+      wrapped_dict = json.load(open(fn, 'r'))
+      if len(wrapped_dict.keys()) > 0 :
+        dict = wrapped_dict[wrapped_dict.keys()[0]]
+        dict['source'] = fn
+        user_pat_configs.append(dict)
+  return user_pat_configs
 
-print ",\n".join(json_lines)
+if __name__ == "__main__" :
+  username = sys.argv[1]
+  store_user = getUserHDFSlisting(username)
+  user_pat_configs = findUserPatConfigJsonFiles(username)
+
+  pat_locations = {}
+  for name, datadef in datadefs.iteritems() :
+    pat_locations[name] = []
+    if 'datasetpath' in datadef :
+      for dir in store_user :
+        if datadef['datasetpath'] in dir :
+          loc = {}
+          loc['dir'] = '/hdfs'+dir
+          for config in user_pat_configs :
+            if config['PAT Location'] == loc['dir'] :
+              loc['possible PAT config'] = config
+          pat_locations[name].append(loc)
+    if len(pat_locations[name]) == 0 :
+      pat_locations.pop(name)
+
+  print json.dumps(pat_locations, indent=4, separators=(',',': '))

--- a/MetaData/tuples/findUserTuples.py
+++ b/MetaData/tuples/findUserTuples.py
@@ -1,0 +1,26 @@
+from FinalStateAnalysis.MetaData.datadefs import datadefs
+import subprocess
+
+def getUserHDFSlisting ( username ) :
+  cmd = ['hdfs dfs']
+  cmd.append('-ls -R')
+  cmd.append('/store/user/'+username)
+  listing = subprocess.Popen(" ".join(cmd), shell=True, stdout=subprocess.PIPE).stdout.read()
+  files = [l.split() for l in listing.split('\n')]
+  dirs = [file[-1] for file in files if len(file) > 0 and file[0][0] == 'd']
+  # keep only deepest level directories
+  dir_subset = []
+  for i in range(0, len(dirs)-1) :
+    if not dirs[i] in dirs[i+1] :
+      dir_subset.append(dirs[i])
+  return dir_subset
+
+store_user = getUserHDFSlisting('nsmith')
+json_lines = []
+for name, datadef in datadefs.iteritems() :
+  if 'datasetpath' in datadef :
+    for dir in store_user :
+      if datadef['datasetpath'] in dir :
+        json_lines.append('    "%s" : "%s"' % (name, '/hdfs'+dir) )
+
+print ",\n".join(json_lines)

--- a/MetaData/tuples/findUserTuples.sh
+++ b/MetaData/tuples/findUserTuples.sh
@@ -7,4 +7,4 @@ then
 fi
 user=$1
 campaign=$2
-hdfs dfs -ls -R /store/user/${user} |grep "${campaign}$"|sed "s:.*/store/user/${user}/\(.*\)/\(.*/AODSIM/.*\):    '\1' \: '/store/user/${user}/\1/\2':"
+hdfs dfs -ls -R /store/user/${user} |grep "${campaign}$"|sed "s:.*/store/user/${user}/\(.*\)/\(.*/AODSIM/.*\):    \"\1\" \: \"/store/user/${user}/\1/\2\",:"

--- a/MetaData/tuples/findUserTuples.sh
+++ b/MetaData/tuples/findUserTuples.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [[ ! $# == 2 ]];
+then
+  echo "Usage: ${0} user campaign"
+  exit
+fi
+user=$1
+campaign=$2
+hdfs dfs -ls -R /store/user/${user} |grep "${campaign}$"|sed "s:.*/store/user/${user}/\(.*\)/\(.*/AODSIM/.*\):    '\1' \: '/store/user/${user}/\1/\2':"

--- a/MetaData/tuples/scrape_pat_config.sh
+++ b/MetaData/tuples/scrape_pat_config.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+user=$1
+for fsadir in `find /afs/hep.wisc.edu/cms/${user}/ -maxdepth 4 -type d -name FinalStateAnalysis`
+do
+  pat="${fsadir}/PatTools/test"
+  if [ -d $pat ]
+  then
+    find $pat -name "*.json"
+  fi
+done


### PR DESCRIPTION
I made a branch for people to push commits referencing #378
When everyone's satisfied the locations are updated, we can merge and delete this branch.
To add commits to this PR, do

```
git checkout -b UpdatedDatadefsFeb15 uwcms/UpdatedDatadefsFeb15
...hack...hack
git commit
git push
```

I made a tool to look for PAT directories in hdfs and match them to `data8TeV.py` datadefs, it might help speed up the process.
You can find it in `MetaData/tuples`
Example usage: `./findUserTuples.py nsmith`
Here is some output for a few users: http://www.hep.wisc.edu/~nsmith/userPAT.html
