### PR TITLE
Check python version before adding arparse module

### DIFF
--- a/recipe/install_python.sh
+++ b/recipe/install_python.sh
@@ -45,8 +45,10 @@ echo "Install progressbar"
 pip install -U progressbar
 echo "Install cython"
 pip install -U cython
-echo "Installing argparse"
-pip install -U argparse
+if ! python -c 'import argparse' 2>/dev/null; then
+    echo "Installing argparse"
+    pip install -U argparse
+fi
 echo "Installing pudb <-- interactive debugging"
 pip install -U pudb
 echo "Installing yellowhiggs <-- higgs yellow report x-sections lookup table"


### PR DESCRIPTION
Python > 2.6 includes the argparse module by default, in which case
there's no reason to add it.
