### PR TITLE
Jet info, muon ghost cleaning, several new branches needed for HZZ4l analysis

### DIFF
--- a/DataFormats/interface/PATFinalState.h
+++ b/DataFormats/interface/PATFinalState.h
@@ -309,11 +309,12 @@ class PATFinalState : public pat::PATObject<reco::LeafCandidate> {
     double twoParticleDeltaPhiToMEt(const int i, const int j, const std::string& metTag) const;
     
     const float getIP3D(const size_t i) const;
+    const float getIP3DErr(const size_t i) const;
 
-    const float getIP3DSig(const size_t i) const;
+    const float getIP2D(const size_t i) const;
+    const float getIP2DErr(const size_t i) const;
 
     const float getPVDZ(const size_t i) const;
-
     const float getPVDXY(const size_t i) const;
 
     const bool isTightMuon(const size_t i) const;
@@ -323,6 +324,9 @@ class PATFinalState : public pat::PATObject<reco::LeafCandidate> {
 
     // Helper function to get global track hits for muon i
     const int getMuonHits(const size_t i) const;
+    
+    // Is the PV the closest vertex to the gen vertex for this object?
+    const bool genVtxPVMatch(const size_t i) const;
 
   private:
     edm::Ptr<PATFinalStateEvent> event_;

--- a/DataFormats/interface/PATFinalState.h
+++ b/DataFormats/interface/PATFinalState.h
@@ -322,6 +322,10 @@ class PATFinalState : public pat::PATObject<reco::LeafCandidate> {
     // Helper function to get missing inner tracker hits for electron i
     const int getElectronMissingHits(const size_t i) const;
 
+    // Get the distance from this electron to the nearest muon passing 
+    // (isPFMuon || isGlobalMuon) and a few loose quality cuts
+    const float electronClosestMuonDR(const size_t i) const;
+
     // Helper function to get global track hits for muon i
     const int getMuonHits(const size_t i) const;
     

--- a/DataFormats/src/PATFinalState.cc
+++ b/DataFormats/src/PATFinalState.cc
@@ -1214,6 +1214,28 @@ const int PATFinalState::getElectronMissingHits(const size_t i) const
   return -1;
 }
 
+const float PATFinalState::electronClosestMuonDR(const size_t i) const
+{
+  float closestDR = 999;
+  for(pat::MuonCollection::const_iterator iMu = evt()->muons().begin();
+      iMu != evt()->muons().end(); ++iMu)
+    {
+      if(!( // have to pass loose muon cuts + global or PF muon
+	   (iMu->isGlobalMuon() || iMu->isPFMuon())
+	   && iMu->pt() > 5 
+	   && fabs(iMu->eta()) < 2.4
+	   && iMu->muonBestTrack()->dxy(evt()->pv()->position()) < 0.5
+	   && iMu->muonBestTrack()->dz(evt()->pv()->position()) < 1.
+	   ))
+	continue;
+      float thisDR = reco::deltaR(daughter(i)->p4(), iMu->p4());
+      if(thisDR < closestDR)
+	closestDR = thisDR;
+    }
+
+  return closestDR;
+}
+
 const int PATFinalState::getMuonHits(const size_t i) const
 {
   if(daughterAsMuon(i)->globalTrack().isNonnull())

--- a/DataFormats/src/PATFinalState.cc
+++ b/DataFormats/src/PATFinalState.cc
@@ -1106,7 +1106,7 @@ const float PATFinalState::getIP3D(const size_t i) const
   return dynamic_cast<const pat::PATObject<reco::Candidate>* >(daughter(i))->userFloat("ip3D");
 }
 
-const float PATFinalState::getIP3DSig(const size_t i) const
+const float PATFinalState::getIP3DErr(const size_t i) const
 {
   if(event_->isMiniAOD())
     {
@@ -1120,6 +1120,44 @@ const float PATFinalState::getIP3DSig(const size_t i) const
 	}
       
       throw cms::Exception("InvalidParticle") << "FSA can only find SIP3D for electron and muon for now" << std::endl;
+    }
+
+return static_cast<const pat::PATObject<reco::Candidate> *>(daughter(i))->userFloat("ip3DS");
+}
+
+const float PATFinalState::getIP2D(const size_t i) const
+{
+  if(event_->isMiniAOD())
+    {
+      if(abs(daughter(i)->pdgId()) == 11)
+	{
+	  return fabs(daughterAsElectron(i)->dB(pat::Electron::PV2D));
+	}
+      else if (abs(daughter(i)->pdgId()) == 13)
+	{
+	  return fabs(daughterAsMuon(i)->dB(pat::Muon::PV2D));
+	}
+      
+      throw cms::Exception("InvalidParticle") << "FSA can only find SIP3D for electron and muon for now" << std::endl;
+    }
+
+  return dynamic_cast<const pat::PATObject<reco::Candidate>* >(daughter(i))->userFloat("ip3D");
+}
+
+const float PATFinalState::getIP2DErr(const size_t i) const
+{
+  if(event_->isMiniAOD())
+    {
+      if(abs(daughter(i)->pdgId()) == 11)
+	{
+	  return daughterAsElectron(i)->edB(pat::Electron::PV2D);
+	}
+      else if (abs(daughter(i)->pdgId()) == 13)
+	{
+	  return daughterAsMuon(i)->edB(pat::Muon::PV2D);
+	}
+      
+      throw cms::Exception("InvalidParticle") << "FSA can only find SIP2D for electron and muon for now" << std::endl;
     }
 
 return static_cast<const pat::PATObject<reco::Candidate> *>(daughter(i))->userFloat("ip3DS");
@@ -1139,10 +1177,8 @@ const float PATFinalState::getPVDZ(const size_t i) const
 	  const edm::Ptr<reco::Vertex> pv = event_->pv();
 	  return daughterAsMuon(i)->muonBestTrack()->dz(pv->position());
 	}
-      
       throw cms::Exception("InvalidParticle") << "FSA can only find dZ for electron and muon for now" << std::endl;
     }
-  
   return dynamic_cast<const pat::PATObject<reco::Candidate> *>(daughter(i))->userFloat("dz");
 }
 
@@ -1160,10 +1196,8 @@ const float PATFinalState::getPVDXY(const size_t i) const
 	  const edm::Ptr<reco::Vertex> pv = event_->pv();
 	  return daughterAsMuon(i)->muonBestTrack()->dxy(pv->position());
 	}
-      
       throw cms::Exception("InvalidParticle") << "FSA can only find dXY for electron and muon for now" << std::endl;
     }
-  
   return dynamic_cast<const pat::PATObject<reco::Candidate> *>(daughter(i))->userFloat("ipDXY");
 }
 
@@ -1188,7 +1222,25 @@ const int PATFinalState::getMuonHits(const size_t i) const
   return -1;
 }
 
+const bool PATFinalState::genVtxPVMatch(const size_t i) const
+{
+  unsigned int pdgId = abs(daughter(i)->pdgId());
+  if(!(getDaughterGenParticle(i, pdgId, 0).isAvailable() && getDaughterGenParticle(i, pdgId, 0).isNonnull()))
+    return false;
 
+  float genVZ = getDaughterGenParticle(i, pdgId, 0)->vz();
+  float genVtxPVDZ = fabs(event_->pv()->z() - genVZ);
+
+  // Loop over all vertices, and if there's one that's better, say so
+  for(edm::PtrVector<reco::Vertex>::const_iterator iVtx = event_->recoVertices().begin();
+      iVtx != event_->recoVertices().end(); ++iVtx)
+    {
+      if(fabs((*iVtx)->z() - genVZ) < genVtxPVDZ)
+	return false;
+    }
+  // Didn't find a better one, PV must be the best
+  return true;
+}
 
 
 

--- a/DataFormats/src/PATFinalState.cc
+++ b/DataFormats/src/PATFinalState.cc
@@ -1209,7 +1209,7 @@ const bool PATFinalState::isTightMuon(const size_t i) const
 const int PATFinalState::getElectronMissingHits(const size_t i) const
 {
   if(daughterAsElectron(i)->gsfTrack().isNonnull())
-    return daughterAsElectron(i)->gsfTrack()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
+    return daughterAsElectron(i)->gsfTrack()->hitPattern().numberOfHits(reco::HitPattern::MISSING_INNER_HITS);
   std::cout << "Daughter " << i << " has null gsf track" << std::endl;
   return -1;
 }

--- a/NtupleTools/python/ntuple_builder.py
+++ b/NtupleTools/python/ntuple_builder.py
@@ -345,7 +345,6 @@ def make_ntuple(*legs, **kwargs):
             # topology.py
             "[emtgj][1-9]?MtToMVAMET", # not yet implemented in miniAOD
             # candidates.py
-            "t[1-9]?IP3D(Sig)?", # tau impact parameter interface is weird, will add if anyone needs it
             "t[1-9]?PVDZ",
             "t[1-9]?PVDXY",
             #
@@ -354,7 +353,7 @@ def make_ntuple(*legs, **kwargs):
             "eMVAIDH2TauWP",
 #            "\w*201[12]\w*",
             "\w*[(Fall)(Winter)(Spring)(Summer)]1[12]\w*",
-            "t[1-9]?S?IP3D(Sig)?",
+            "t[1-9]?S?IP[23]D(Err)?",
             ]
 
         allRemovals = re.compile("(" + ")|(".join(notInMiniAOD) + ")")

--- a/NtupleTools/python/ntuple_builder.py
+++ b/NtupleTools/python/ntuple_builder.py
@@ -248,6 +248,16 @@ def make_ntuple(*legs, **kwargs):
         )
     #pdb.set_trace()
 
+    # If basic jet information is desired for a non-jet final state, put it in
+    for i in range(1,kwargs.get("nExtraJets", 0)+1):
+        label = "jet%i"%i
+        format_labels[label] = 'evt.jets.at(%i)' % i
+        format_labels[label + '_idx'] = '%i' % i
+        
+        ntuple_config = PSet(
+            ntuple_config,
+            templates.topology.extraJet.replace(object=label)
+            )
     
     # Now we need to add all the information about the pairs
     for leg_a, leg_b in itertools.combinations(object_labels, 2):

--- a/NtupleTools/python/templates/candidates.py
+++ b/NtupleTools/python/templates/candidates.py
@@ -21,10 +21,12 @@ kinematics = PSet(
 vertex_info = PSet(
     objectVZ = '{object}.vz',
     objectIP3D = 'getIP3D({object_idx})',
-    objectIP3DSig = 'getIP3DSig({object_idx})', # uncertainty ("significance") of IP3D
-    objectSIP3D = 'getIP3D({object_idx}) / getIP3DSig({object_idx})',
+    objectIP3DErr = 'getIP3DErr({object_idx})', # uncertainty of IP3D
+    objectSIP3D = 'getIP3D({object_idx}) / getIP3DErr({object_idx})',
     objectPVDZ = 'getPVDZ({object_idx})',
     objectPVDXY = 'getPVDXY({object_idx})',
+    objectSIP2D = 'getIP2D({object_idx}) / getIP2DErr({object_idx})',
+#    objectPVAssociation = '{object}.fromPV', # 0->used in PV fit, 1->PV is closest VTX, 2->other VTX is closest, 3->used in other VTX fit
 )
 
 # The info about the associated pat::Jet

--- a/NtupleTools/python/templates/electrons.py
+++ b/NtupleTools/python/templates/electrons.py
@@ -95,6 +95,8 @@ id = PSet(
     objectGenEnergy      = '? (getDaughterGenParticle({object_idx}, 11, 0).isAvailable && getDaughterGenParticle({object_idx}, 11, 0).isNonnull) ? getDaughterGenParticle({object_idx}, 11, 0).energy() : -999',
     objectGenEta         = '? (getDaughterGenParticle({object_idx}, 11, 0).isAvailable && getDaughterGenParticle({object_idx}, 11, 0).isNonnull) ? getDaughterGenParticle({object_idx}, 11, 0).eta()   : -999',
     objectGenPhi         = '? (getDaughterGenParticle({object_idx}, 11, 0).isAvailable && getDaughterGenParticle({object_idx}, 11, 0).isNonnull) ? getDaughterGenParticle({object_idx}, 11, 0).phi()   : -999',
+    objectGenVZ          = '? (getDaughterGenParticle({object_idx}, 11, 0).isAvailable && getDaughterGenParticle({object_idx}, 11, 0).isNonnull) ? getDaughterGenParticle({object_idx}, 11, 0).vz()   : -999',
+    objectGenVtxPVMatch  = 'genVtxPVMatch({object_idx})', # is PV closest vtx to gen vtx?
 )
 
 energyCorrections = PSet(

--- a/NtupleTools/python/templates/electrons.py
+++ b/NtupleTools/python/templates/electrons.py
@@ -175,10 +175,7 @@ energyCorrections = PSet(
 
 tracking = PSet(
     objectHasConversion = '{object}.userFloat("hasConversion")',
-#     objectMissingHits = 'getElectronMissingHits({object_idx})',
-#                         cms.string(
-#         '? {object}.gsfTrack().isNonnull ? '
-#         '{object}.gsfTrack().hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) : 10'), 
+    objectMissingHits = 'getElectronMissingHits({object_idx})',
 )
 
 # Information about the matched supercluster

--- a/NtupleTools/python/templates/electrons.py
+++ b/NtupleTools/python/templates/electrons.py
@@ -97,6 +97,9 @@ id = PSet(
     objectGenPhi         = '? (getDaughterGenParticle({object_idx}, 11, 0).isAvailable && getDaughterGenParticle({object_idx}, 11, 0).isNonnull) ? getDaughterGenParticle({object_idx}, 11, 0).phi()   : -999',
     objectGenVZ          = '? (getDaughterGenParticle({object_idx}, 11, 0).isAvailable && getDaughterGenParticle({object_idx}, 11, 0).isNonnull) ? getDaughterGenParticle({object_idx}, 11, 0).vz()   : -999',
     objectGenVtxPVMatch  = 'genVtxPVMatch({object_idx})', # is PV closest vtx to gen vtx?
+    
+    # How close is the nearest muon passing some basic quality cuts?
+    objectNearestMuonDR = "electronClosestMuonDR({object_idx})",
 )
 
 energyCorrections = PSet(

--- a/NtupleTools/python/templates/event.py
+++ b/NtupleTools/python/templates/event.py
@@ -37,7 +37,8 @@ pv_info = PSet(
     pvndof='? evt.pv.isNonnull() ? evt.pv.ndof : -999',
     pvNormChi2='? evt.pv.isNonnull() ? evt.pv.normalizedChi2 : -999',
     pvIsValid=cms.vstring('? evt.pv.isNonnull() ? evt.pv.isValid : 0', 'I'),
-    pvIsFake=cms.vstring('? evt.pv.isNonnull() ? evt.pv.isFake : 1', 'I')
+    pvIsFake=cms.vstring('? evt.pv.isNonnull() ? evt.pv.isFake : 1', 'I'),
+    pvRho = 'evt.pv.position.Rho',
 )
 
 met = PSet(

--- a/NtupleTools/python/templates/muons.py
+++ b/NtupleTools/python/templates/muons.py
@@ -95,6 +95,8 @@ id = PSet(
     objectGenEnergy      = '? (getDaughterGenParticle({object_idx}, 13, 0).isAvailable && getDaughterGenParticle({object_idx}, 13, 0).isNonnull) ? getDaughterGenParticle({object_idx}, 13, 0).energy() : -999',
     objectGenEta         = '? (getDaughterGenParticle({object_idx}, 13, 0).isAvailable && getDaughterGenParticle({object_idx}, 13, 0).isNonnull) ? getDaughterGenParticle({object_idx}, 13, 0).eta()   : -999',
     objectGenPhi         = '? (getDaughterGenParticle({object_idx}, 13, 0).isAvailable && getDaughterGenParticle({object_idx}, 13, 0).isNonnull) ? getDaughterGenParticle({object_idx}, 13, 0).phi()   : -999',
+    objectGenVZ          = '? (getDaughterGenParticle({object_idx}, 13, 0).isAvailable && getDaughterGenParticle({object_idx}, 13, 0).isNonnull) ? getDaughterGenParticle({object_idx}, 13, 0).vz()   : -999',
+    objectGenVtxPVMatch  = 'genVtxPVMatch({object_idx})', # is PV closest vtx to gen vtx?
 )
 
 energyCorrections = PSet(

--- a/NtupleTools/python/templates/muons.py
+++ b/NtupleTools/python/templates/muons.py
@@ -84,6 +84,7 @@ id = PSet(
     ##     "/{object}.pt()"
     ## ),
 
+    objectIsPFMuon = '{object}.isPFMuon',
     objectIsGlobal = '{object}.isGlobalMuon',
     objectIsTracker = '{object}.isTrackerMuon',
     objectTypeCode = cms.vstring('{object}.type','I'),

--- a/NtupleTools/python/templates/topology.py
+++ b/NtupleTools/python/templates/topology.py
@@ -146,3 +146,10 @@ vbf = PSet(
    vbfditaupt = 'vbfVariables("pt >30").ditaupt',
 )
 
+
+extraJet = PSet(
+    objectPt = '? evt.jets.size()>{object_idx} ? {object}.pt() : -999',
+    objectEta = '? evt.jets.size()>{object_idx} ? {object}.eta() : -999',
+    objectPhi = '? evt.jets.size()>{object_idx} ? {object}.phi() : -999',
+    objectPUMVA = '? evt.jets.size()>{object_idx} ? {object}.userFloat("pileupJetId:fullDiscriminant") : -999',
+)

--- a/NtupleTools/test/README.rst
+++ b/NtupleTools/test/README.rst
@@ -36,7 +36,8 @@ zero or one) are::
     useMiniAOD=1            - run over miniAOD samples rather than UW pattuples
     runDQM=0                - run on single objects instead of final states, plotting many quantities to make sure things work
     use25ns=1               - (with useMiniAOD=1) use conditions for 25ns CSA14 miniAOD samples
-    hzzfsr=0                - (with useMiniAOD=1. DO NOT use with zz_mode=1) run the HZZ4l group's FSR algorithm on miniAOD
+    hzzfsr=0                - (with useMiniAOD=1; DO NOT use with zz_mode=1) run the HZZ4l group's FSR algorithm on miniAOD
+    nExtraJets=0            - (for non-jet final states) add basic info about this many jets in addition to final state branches
 
 Batch submission
 ----------------

--- a/NtupleTools/test/make_ntuples_cfg.py
+++ b/NtupleTools/test/make_ntuples_cfg.py
@@ -41,6 +41,7 @@ useMiniAOD=1 - run on miniAOD rather than UW PATTuples (default)
 use25ns=1 - run on 25 ns miniAOD (default, 0 = 50ns)
 runDQM=0 - run over single object final states to test all object properties (wont check diobject properties)
 hzzfsr=0 - Include FSR contribution a la HZZ4l group
+nExtraJets=0 - Include basic info about this many jets (ordered by pt). Ignored if final state involves jets.
 
 
 '''
@@ -102,6 +103,13 @@ options.register(
     TauVarParsing.TauVarParsing.multiplicity.list,
     TauVarParsing.TauVarParsing.varType.string,
     'additional cuts to impose on the NTuple'
+)
+options.register(
+    'nExtraJets',
+    0,
+    TauVarParsing.TauVarParsing.multiplicity.singleton,
+    TauVarParsing.TauVarParsing.varType.int,
+    'Number of pt-ordered jets to keep some info about. Ignored if final state involves jets.',
 )
 
 
@@ -528,7 +536,6 @@ if options.runDQM: options.channels = 'dqm'
 # Generate analyzers which build the desired final states.
 final_states = [x.strip() for x in options.channels.split(',')]
 
-
 def expanded_final_states(input):
     for fs in input:
         if fs in _FINAL_STATE_GROUPS:
@@ -540,12 +547,13 @@ def expanded_final_states(input):
 
 print "Building ntuple for final states: %s" % ", ".join(final_states)
 for final_state in expanded_final_states(final_states):
+    extraJets = options.nExtraJets if 'j' not in final_state else 0
     zz_mode = (final_state in ['mmmm', 'eeee', 'eemm'])
     analyzer = make_ntuple(*final_state, zz_mode=options.zzMode,
                             svFit=options.svFit, dblhMode=options.dblhMode,
                             runTauSpinner=options.runTauSpinner, 
                             skimCuts=options.skimCuts,useMiniAOD=options.useMiniAOD,
-                            hzzfsr=options.hzzfsr)
+                            hzzfsr=options.hzzfsr, nExtraJets=extraJets)
     add_ntuple(final_state, analyzer, process,
                process.schedule, options.eventView)
 

--- a/NtupleTools/test/make_ntuples_cfg.py
+++ b/NtupleTools/test/make_ntuples_cfg.py
@@ -353,6 +353,18 @@ if options.rerunFSA:
             )
         process.schedule.append(process.miniAODElectrons)
 
+        # Clean out muon "ghosts" caused by track ambiguities
+        process.ghostCleanedMuons = cms.EDProducer("PATMuonCleanerBySegments",
+                                                   src = cms.InputTag(fs_daughter_inputs['muons']),
+                                                   preselection = cms.string("track.isNonnull"),
+                                                   passthrough = cms.string("isGlobalMuon && numberOfMatches >= 2"),
+                                                   fractionOfSharedSegments = cms.double(0.499))
+        output_commands.append('*_ghostCleanedMuons_*_*')
+        fs_daughter_inputs['muons'] = "ghostCleanedMuons"
+
+        process.miniCleanedMuons = cms.Path(process.ghostCleanedMuons)
+        process.schedule.append(process.miniCleanedMuons)
+
         process.miniPatMuons = cms.EDProducer(
             "MiniAODMuonIDEmbedder",
             src=cms.InputTag(fs_daughter_inputs['muons']),


### PR DESCRIPTION
Kind of random assortment of changes here, mostly new branches. The most significant are the addition of default muon ghost cleaning and an option to put basic info about the N highest-pt jets into the ntuple for non-jet final states. Right now just does pt, eta, phi, and PU MVA, but could easily do more. 

@kdlong, this might be relevant to your interests.
