### PR TITLE
Small changes NtupleTools README and submit_job.py.

### DIFF
--- a/NtupleTools/test/README.rst
+++ b/NtupleTools/test/README.rst
@@ -44,8 +44,8 @@ Batch submission
 
 The jobs can be submitted to condor using the ``submit_job.py`` script, found in
 the FinalStateAnalysis/Utilities/scripts folder. Run submit_job.py -h to view the
-list of possible command line options. By default, submit_job.py creates text for
-a bash script to submit jobs via FarmoutAnalysisJobs.
+list of possible command line options. submit_job.py creates text for a bash script 
+to submit jobs via FarmoutAnalysisJobs.
 (see http://www.hep.wisc.edu/cms/comp/faq.html#how-can-i-use-farmoutanalysisjobs...)
 By default the output of this script is printed to stdout. You can also use the option
 --output_file (-o) to create a script with this information. 
@@ -65,7 +65,7 @@ can be found in MetData/tuples/MiniAOD-13TeV.json) by using the option --das-rep
 The command would then use the shorthand names for lookup::
 
 
-   submit_job.py MiniAOD_Test make_ntuples_cfg.py channels="eeee,eeem,eemm,emmm,mmmm,eee,eem,emm,mmm" isMC=1 --campaign-tag="Phys14DR-PU20bx25_PHYS14_25_V*" --das-replace-tuple=$fsa/MetaData/tuples/MiniAOD-13TeV.json --samples "ZZ*" "WZ*" "DY*" > do_test.sh
+   submit_job.py MiniAOD_Test make_ntuples_cfg.py channels="eeee,eeem,eemm,emmm,mmmm,eee,eem,emm,mmm" isMC=1 --campaign-tag="Phys14DR-PU20bx25_PHYS14_25_V*" --das-replace-tuple=$fsa/MetaData/tuples/MiniAOD-13TeV.json --samples "ZZ*" "WZ*" "DY*" -o do_test.sh
    bash < do_test.sh
 
 

--- a/NtupleTools/test/README.rst
+++ b/NtupleTools/test/README.rst
@@ -43,7 +43,12 @@ Batch submission
 ----------------
 
 The jobs can be submitted to condor using the ``submit_job.py`` script, found in
-the FinalStateAnalysis/Utilities/scripts folder.  
+the FinalStateAnalysis/Utilities/scripts folder. Run submit_job.py -h to view the
+list of possible command line options. By default, submit_job.py creates text for
+a bash script to submit jobs via FarmoutAnalysisJobs.
+(see http://www.hep.wisc.edu/cms/comp/faq.html#how-can-i-use-farmoutanalysisjobs...)
+By default the output of this script is printed to stdout. You can also use the option
+--output_file (-o) to create a script with this information. 
 
 The following will run a bunch of PHYS14 miniAOD files. As new MiniAOD versions are released,
 you only need to change the campaign-tag. This command uses a DAS lookup to find all available
@@ -52,12 +57,12 @@ the campaign tag should avoid repeated datasets (since old datasets should be in
 the new ones arrive: example, *-v1 should not appear if *-v2 has been released). Most other
 things are now taken care of without special options (miniaod 25ns has been made default)::
 
-   submit_job.py MiniAOD_Test make_ntuples_cfg.py channels="eeee,eeem,eemm,emmm,mmmm,eee,eem,emm,mmm" isMC=1 --campaign-tag="Phys14DR-PU20bx25_PHYS14_25_V*" --samples "ZZTo4L*" "WZJetsTo3LNu*" "WJetsToLNu_13TeV*" "T*_tW*" "T*ToLeptons_*" "TTW*" "TTZ*" "TTJets_MSDecaysCKM*" "DYJetsToLL_M-50_13TeV*" > do_test.sh 
+   submit_job.py MiniAOD_Test make_ntuples_cfg.py channels="eeee,eeem,eemm,emmm,mmmm,eee,eem,emm,mmm" isMC=1 --campaign-tag="Phys14DR-PU20bx25_PHYS14_25_V*" --samples "ZZTo4L*" "WZJetsTo3LNu*" "WJetsToLNu_13TeV*" "T*_tW*" "T*ToLeptons_*" "TTW*" "TTZ*" "TTJets_MSDecaysCKM*" "DYJetsToLL_M-50_13TeV*" -o do_test.sh
    bash < do_test.sh
 
 Alternatively, you can define a shorthand json to simplify the selection ntuple names (an example
-can be found in MetData/tuples/MiniAOD-13TeV.json). The command would then use the shorthand
-names for lookup::
+can be found in MetData/tuples/MiniAOD-13TeV.json) by using the option --das-replace-tuple=file.json. 
+The command would then use the shorthand names for lookup::
 
 
    submit_job.py MiniAOD_Test make_ntuples_cfg.py channels="eeee,eeem,eemm,emmm,mmmm,eee,eem,emm,mmm" isMC=1 --campaign-tag="Phys14DR-PU20bx25_PHYS14_25_V*" --das-replace-tuple=$fsa/MetaData/tuples/MiniAOD-13TeV.json --samples "ZZ*" "WZ*" "DY*" > do_test.sh

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Checkout the needed CMSSW tags:
   # Checkout needed packages and apply patches
   # This enables all options.  You can turn off things you don't need.
   PATPROD=1 LUMI=1 LIMITS=0 ./recipe.sh
+  # Setup FSA environment
+  source environment.sh
   # Compile
   cd ../../
-  # Avoid the new strict version of the compiler by relaxing some flags
-  export USER_CXXFLAGS="-Wno-delete-non-virtual-dtor -Wno-error=unused-but-set-variable -Wno-error=unused-variable -Wno-error=sign-compare -Wno-error=reorder"
   scram b -j 8
 ```
 

--- a/Utilities/scripts/submit_job.py
+++ b/Utilities/scripts/submit_job.py
@@ -3,7 +3,9 @@
 '''
 
 Create a script file to submit jobs to condor using farmoutAnalysisJobs. 
-The script is written to stdout, some logging information is sent to stderr.
+By default, the script is written to stdout, with some logging information 
+sent to stderr. If --output_file (-o) is specified, a bash script is
+created containing the ouput.
 
 
 Example to make submit script for VH analysis:
@@ -126,8 +128,8 @@ def get_com_line_args():
                                help='Clean crab dupes')
 
     parser.add_argument('--output_file', '-o', type=str, default="",
-                        required=False, help="Create Bash file with ouput rather than"
-                        "printing information to stdout")
+                        required=False, help="Create bash script OUTPUT_FILE file with ouput "
+                        "rather than printing information to stdout")
     args = parser.parse_args()
     return args
 

--- a/Utilities/scripts/submit_job.py
+++ b/Utilities/scripts/submit_job.py
@@ -2,8 +2,9 @@
 
 '''
 
-Create a script file to submit jobs to condor.  The script is written to stdout,
-some logging information is sent to stderr.
+Create a script file to submit jobs to condor using farmoutAnalysisJobs. 
+The script is written to stdout, some logging information is sent to stderr.
+
 
 Example to make submit script for VH analysis:
 
@@ -12,7 +13,7 @@ Example to make submit script for VH analysis:
 
 '''
 
-from RecoLuminosity.LumiDB import argparse
+import argparse
 import datetime
 import fnmatch
 import json
@@ -25,8 +26,7 @@ from FinalStateAnalysis.Utilities.dbsinterface import get_das_info
 log = logging.getLogger("submit_job")
 logging.basicConfig(level=logging.INFO, stream=sys.stderr)
 
-
-if __name__ == "__main__":
+def get_com_line_args():
     parser = argparse.ArgumentParser()
 
     cmsrun_group = parser.add_argument_group('Analysis and cmsRun options')
@@ -125,15 +125,18 @@ if __name__ == "__main__":
                                default=False, dest='cleancrab',
                                help='Clean crab dupes')
 
+    parser.add_argument('--output_file', '-o', type=str, default="",
+                        required=False, help="Create Bash file with ouput rather than"
+                        "printing information to stdout")
     args = parser.parse_args()
+    return args
 
-    sys.stdout.write('# Condor submission script\n')
-    sys.stdout.write('# Generated with submit_job.py at %s\n'
-                     % datetime.datetime.now())
-    sys.stdout.write('# The command was: %s\n' % ' '.join(sys.argv))
-
-    sys.stdout.write('export TERMCAP=screen\n')
-
+if __name__ == "__main__":
+    output = '# Condor submission script\n'
+    output += '# Generated with submit_job.py at %s\n' % datetime.datetime.now()
+    output += '# The command was: %s\n' % ' '.join(sys.argv)
+    output += 'export TERMCAP=screen\n'
+    args = get_com_line_args()
     # first, make DAS query for dataset if not using local dataset or hdfs/dbs tuple list
     if args.campaignstring:
         dbs_datasets = get_das_info('/*/%s/MINIAOD*' % args.campaignstring)
@@ -232,9 +235,9 @@ if __name__ == "__main__":
                 if lastRun > 0:
                     command.append('lastRun=%i' % lastRun)
 
-            sys.stdout.write('# Submit file for sample %s\n' % dataset_name)
-            sys.stdout.write('mkdir -p %s\n' % os.path.dirname(dag_dir))
-            sys.stdout.write(' '.join(command) + '\n')
+            output += '# Submit file for sample %s\n' % dataset_name
+            output += 'mkdir -p %s\n' % os.path.dirname(dag_dir)
+            output += ' '.join(command) + '\n'
     else:
         # this is the old version that uses datadefs
         for sample, sample_info in reversed(
@@ -381,6 +384,15 @@ if __name__ == "__main__":
                 if lastRun > 0:
                     command.append('lastRun=%i' % lastRun)
 
-            sys.stdout.write('# Submit file for sample %s\n' % sample)
-            sys.stdout.write('mkdir -p %s\n' % os.path.dirname(dag_dir))
-            sys.stdout.write(' '.join(command) + '\n')
+            output += '# Submit file for sample %s\n' % sample
+            output += 'mkdir -p %s\n' % os.path.dirname(dag_dir)
+            output += ' '.join(command) + '\n'
+
+    if args.output_file == "":
+        sys.stdout.write(output)
+    else:
+        with open(args.output_file, "w") as file:
+            file.write("#!/bin/bash")
+            file.write(output)
+        sys.stdout.write("\nWrote submit script %s\n" % args.output_file)
+

--- a/Utilities/scripts/submit_job.py
+++ b/Utilities/scripts/submit_job.py
@@ -10,11 +10,6 @@ sent to stderr. If --output_file (-o) is specified, a bash script is
 created containing the ouput.
 
 
-Example to make submit script for VH analysis on UW PAT:
-
-    submit_job.py VH 2012-03-14-Trileptons trilepton_ntuples_cfg.py \
-            "--input-dir={myhdfs}/2012-03-05-EWKPatTuple/{sample}"
-
 Example to make submit script (stored in test.sh) for WZ analysis on Phys14 miniAOD:
 (run from $fsa/NtupleTools/test or use full path to make_ntuples_cfg.py)
     
@@ -43,11 +38,11 @@ def datasets_from_das(args):
     ''' Build submit script using datasets from DAS
 
     Builds text for a bash script to submit ntuplization jobs to condor
-    via FarmoutAnalysisJobs. Recieves the command line input to the script
-    (via the varialbe args) as input. The MINIAOD file to be ntuplized is
-    found by searching for files in DAS matching args.samples in the campaign
-    args.campaignstring. If args.dastuple is specified (a json file), this is 
-    used as a simpler lookup method rather than searching through all of DAS. 
+    via FarmoutAnalysisJobs. Recieves the command line input (via the varialbe 
+    args) as input. The MINIAOD file to be ntuplized is found by searching for 
+    files in DAS matching args.samples in the campaign args.campaignstring. If 
+    args.dastuple is specified (a json file), this is used as a simpler lookup 
+    method rather than searching through all of DAS. 
 
     If a submit folder already exists with the same name, it will not be
     recreated. A warning is written to the submit script.
@@ -116,7 +111,7 @@ def datasets_from_das(args):
         input_commands.extend([
             '--input-file-list=%s' % input_txt_path,
             '--assume-input-files-exist', 
-            '--input-dir=root://xrootd.unl.edu/',
+            '--input-dir=root://cmsxrootd.fnal.gov/',
         ])
 
         command = [
@@ -340,12 +335,6 @@ def get_com_line_args():
         action='store_true', help = 'If specified, pass the appropriate '
         'lumiMask=XXX.json and firstRun etc to cmsRun'
     )
-
-    cmsrun_group.add_argument(
-        '--xrootd', action='store_true', required=False, default=False,
-        help='fetch files from remote tiers using xrootd'
-    )
-
     cmsrun_group.add_argument(
         '--das-replace-tuple', dest='dastuple',
          help = 'JSON file listing shorthand names for DAS samples.'

--- a/recipe/environment.sh
+++ b/recipe/environment.sh
@@ -89,7 +89,10 @@ if [ "$MAJOR_VERSION" -eq "5" ]; then
   export dataAODFile=/hdfs/store/user/efriis//double_mu_2012C_data_53X_20events.root
   export patTupleFile=/hdfs/store/user/tapas/DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball/Summer12_DR53X-PU_S10_START53_V7A-v1/AODSIM/2013-03-13-8TeV-53X-PatTuple_Master/patTuple_cfg-00037C53-AAD1-E111-B1BE-003048D45F38.root
 fi
-
+# Some tight compiler flags should be relaxed
+if [ "$MAJOR_VERSION" -eq "7" ]; then
+  export USER_CXXFLAGS="-Wno-delete-non-virtual-dtor -Wno-error=unused-but-set-variable -Wno-error=unused-variable -Wno-error=sign-compare -Wno-error=reorder"
+fi
 # Define the current most-informative PU information JSONs
 export pu2011JSON=/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions11/7TeV/PileUp/pileup_2011_JSON_pixelLumi.txt
 # Final 2012 pileup calculation 


### PR DESCRIPTION
Made a few small changes to submit_job.py (moved two distinct ways of reading datasets into separate functions, with comments), removed "export TERMCAP=screen\n", which isn't necessary unless someone is using screen (is anyone?), and added an option to specify an output file for the script to be written to.

Also made small changes to the README in NtupleTools/test 
