### PR TITLE
Added genPt for e and m, added function to sort states into expected orded

### DIFF
--- a/NtupleTools/python/templates/electrons.py
+++ b/NtupleTools/python/templates/electrons.py
@@ -80,6 +80,7 @@ id = PSet(
     objectGenEnergy      = '? (getDaughterGenParticle({object_idx}, 11, 0).isAvailable && getDaughterGenParticle({object_idx}, 11, 0).isNonnull) ? getDaughterGenParticle({object_idx}, 11, 0).energy() : -999',
     objectGenEta         = '? (getDaughterGenParticle({object_idx}, 11, 0).isAvailable && getDaughterGenParticle({object_idx}, 11, 0).isNonnull) ? getDaughterGenParticle({object_idx}, 11, 0).eta()   : -999',
     objectGenPhi         = '? (getDaughterGenParticle({object_idx}, 11, 0).isAvailable && getDaughterGenParticle({object_idx}, 11, 0).isNonnull) ? getDaughterGenParticle({object_idx}, 11, 0).phi()   : -999',
+    objectGenPt          = '? (getDaughterGenParticle({object_idx}, 11, 0).isAvailable && getDaughterGenParticle({object_idx}, 11, 0).isNonnull) ? getDaughterGenParticle({object_idx}, 11, 0).pt()   : -999',
     objectGenVZ          = '? (getDaughterGenParticle({object_idx}, 11, 0).isAvailable && getDaughterGenParticle({object_idx}, 11, 0).isNonnull) ? getDaughterGenParticle({object_idx}, 11, 0).vz()   : -999',
     objectGenVtxPVMatch  = 'genVtxPVMatch({object_idx})', # is PV closest vtx to gen vtx?
     

--- a/NtupleTools/python/templates/muons.py
+++ b/NtupleTools/python/templates/muons.py
@@ -60,6 +60,7 @@ id = PSet(
     objectGenEnergy      = '? (getDaughterGenParticle({object_idx}, 13, 0).isAvailable && getDaughterGenParticle({object_idx}, 13, 0).isNonnull) ? getDaughterGenParticle({object_idx}, 13, 0).energy() : -999',
     objectGenEta         = '? (getDaughterGenParticle({object_idx}, 13, 0).isAvailable && getDaughterGenParticle({object_idx}, 13, 0).isNonnull) ? getDaughterGenParticle({object_idx}, 13, 0).eta()   : -999',
     objectGenPhi         = '? (getDaughterGenParticle({object_idx}, 13, 0).isAvailable && getDaughterGenParticle({object_idx}, 13, 0).isNonnull) ? getDaughterGenParticle({object_idx}, 13, 0).phi()   : -999',
+    objectGenPt          = '? (getDaughterGenParticle({object_idx}, 13, 0).isAvailable && getDaughterGenParticle({object_idx}, 13, 0).isNonnull) ? getDaughterGenParticle({object_idx}, 13, 0).pt()   : -999',
     objectGenVZ          = '? (getDaughterGenParticle({object_idx}, 13, 0).isAvailable && getDaughterGenParticle({object_idx}, 13, 0).isNonnull) ? getDaughterGenParticle({object_idx}, 13, 0).vz()   : -999',
     objectGenVtxPVMatch  = 'genVtxPVMatch({object_idx})', # is PV closest vtx to gen vtx?
 )

--- a/NtupleTools/test/make_ntuples_cfg.py
+++ b/NtupleTools/test/make_ntuples_cfg.py
@@ -565,6 +565,25 @@ if options.runDQM: options.channels = 'dqm'
 # Generate analyzers which build the desired final states.
 final_states = [x.strip() for x in options.channels.split(',')]
 
+
+def order_final_state(state):
+    '''
+    Sorts final state objects into order expected by FSA.
+    '''
+    order = ['e', 'm', 't', 'g', 'j']
+    counts = dict.fromkeys(order, 0)
+    for letter in state:
+        if letter in counts:
+            counts[letter] += 1
+        else:
+            print 'Warning: Invalid object "%s" in state ignored' \
+                % letter
+    state = ""
+    for letter in order:
+        for i in range(0, counts[letter]):
+            state += letter
+    return state
+
 def expanded_final_states(input):
     for fs in input:
         if fs in _FINAL_STATE_GROUPS:
@@ -573,7 +592,7 @@ def expanded_final_states(input):
         else:
             yield fs
 
-
+final_states = [order_final_state(fs) for fs in final_states]
 print "Building ntuple for final states: %s" % ", ".join(final_states)
 for final_state in expanded_final_states(final_states):
     extraJets = options.nExtraJets if 'j' not in final_state else 0

--- a/NtupleTools/test/make_ntuples_cfg.py
+++ b/NtupleTools/test/make_ntuples_cfg.py
@@ -592,11 +592,11 @@ def expanded_final_states(input):
         else:
             yield fs
 
-final_states = [order_final_state(fs) for fs in final_states]
 print "Building ntuple for final states: %s" % ", ".join(final_states)
 for final_state in expanded_final_states(final_states):
     extraJets = options.nExtraJets if 'j' not in final_state else 0
     zz_mode = (final_state in ['mmmm', 'eeee', 'eemm'])
+    final_state = order_final_state(final_state)
     analyzer = make_ntuple(*final_state, zz_mode=options.zzMode,
                             svFit=options.svFit, dblhMode=options.dblhMode,
                             runTauSpinner=options.runTauSpinner, 


### PR DESCRIPTION
Added genPt for e and m. Added a function into make_ntuples_cfg.py to sort final states into order expected by FSA. For example, 'mem' or 'mme' will be sorted to 'emm' and will no longer cause an error.

Also made aesthetic changes to submit_job.py and documented a "bug" where --samples WZ\* will be expanded by unix if you have a file such as WZ_submit.sh in your directory. Solution is to use quotes, "WZ*"
