### PR TITLE
adding svfit and mvamet

### DIFF
--- a/DataAlgos/BuildFile.xml
+++ b/DataAlgos/BuildFile.xml
@@ -12,7 +12,7 @@
 <use   name="DataFormats/HepMCCandidate"/>
 <use   name="DataFormats/PatCandidates"/>
 <use   name="FWCore/Utilities"/>
-<use   name="TauAnalysis/CandidateTools"/>
+<use   name="TauAnalysis/SVfitStandalone"/>
 <export>
   <lib   name="1"/>
   <use   name="TauAnalysis/CandidateTools"/>

--- a/DataAlgos/interface/ApplySVfit.h
+++ b/DataAlgos/interface/ApplySVfit.h
@@ -1,7 +1,7 @@
 ///////////
 // getSVFit mass
 // based on standalone SVfit instructions
-// https://twiki.cern.ch/twiki/bin/view/CMS/HiggsToTauTauWorking2012#SVFit_Christian_Lorenzo_Aram_Rog
+// https://twiki.cern.ch/twiki/bin/viewauth/CMS/HiggsToTauTauWorking2015#SVfit
 //
 // S.Z. Shalhout (sshalhou@CERN.CH) Nov 20, 2012
 /////////

--- a/DataFormats/interface/PATFinalStateEvent.h
+++ b/DataFormats/interface/PATFinalStateEvent.h
@@ -233,7 +233,7 @@ class PATFinalStateEvent {
     edm::RefProd<pat::PackedCandidateCollection> packedPFRefProd_;
     reco::TrackRefProd tracks_;
     reco::GsfTrackRefProd gsfTracks_;
-    // List of different MET types (non used with miniAOD)
+    // List of different MET types
     std::map<std::string, edm::Ptr<pat::MET> > mets_;
 
 };

--- a/DataFormats/src/PATFinalState.cc
+++ b/DataFormats/src/PATFinalState.cc
@@ -332,16 +332,7 @@ PATFinalState::SVfit(int i, int j) const {
   toFit.push_back(daughterPtr(i));
   toFit.push_back(daughterPtr(j));
 
-  edm::Ptr<pat::MET> mvaMet;
-  if(event_->isMiniAOD())
-    {
-      // Turn this back on when miniAOD gains MVA MET
-      std::cout << "MVA MET doesn't exist in miniAOD yet. How did we even get here!?!?!?" << std::endl;
-    }
-  else
-    {
-      mvaMet = evt()->met("mvamet");
-    }
+  edm::Ptr<pat::MET> mvaMet = evt()->met("mvamet");
 
   if (mvaMet.isNull()) {
     throw cms::Exception("MissingMVAMet")

--- a/NtupleTools/python/ntuple_builder.py
+++ b/NtupleTools/python/ntuple_builder.py
@@ -313,10 +313,6 @@ def make_ntuple(*legs, **kwargs):
         # Remove them from the ntuples to prevent crashes.
         #!!! Take items off of this list as we unbreak them. !!!#
         notInMiniAOD = [
-            # event.py
-            "mva_met((Et)|(Phi))", # not yet implemented in miniAOD
-            # topology.py
-            "[emtgj][1-9]?MtToMVAMET", # not yet implemented in miniAOD
             # candidates.py
             "t[1-9]?PVDZ",
             "t[1-9]?S?IP[23]D(Err)?",

--- a/NtupleTools/python/templates/cleaning.py
+++ b/NtupleTools/python/templates/cleaning.py
@@ -20,6 +20,8 @@ vetos = PSet(
     muGlbIsoVetoPt10 = 'vetoMuons(0.4, "isGlobalMuon & isTrackerMuon & pt > 10 & abs(eta) < 2.4 & (userIso(0) + max(photonIso + neutralHadronIso - 0.5*puChargedHadronIso, 0))/pt < 0.4").size()',
     muVetoPt5IsoIdVtx = 'vetoMuons(0.4, "pt > 5 & abs(eta) < 2.4 & userInt(\'tightID\') > 0.5 & ((userIso(0) + max(photonIso()+neutralHadronIso()-0.5*puChargedHadronIso,0.0))/pt()) < 0.15 & userFloat(\'dz\') < 0.2").size()',
     muVetoPt15IsoIdVtx = 'vetoMuons(0.4, "pt > 15 & abs(eta) < 2.4 & userInt(\'tightID\') > 0.5 & ((userIso(0) + max(photonIso()+neutralHadronIso()-0.5*puChargedHadronIso,0.0))/pt()) < 0.15 & userFloat(\'dz\') < 0.2").size()',
+    muVetoWZ = 'vetoMuons(0.4, "isLooseMuon & pt > 10 & abs(eta) < 2.4").size()',
+    muVetoWZIso = 'vetoMuons(0.4, "isLooseMuon & pt > 10 & abs(eta) < 2.4 & (chargedHadronIso()+max(photonIso()+neutralHadronIso()-0.5*puChargedHadronIso,0.0))/pt() < 0.2").size()',
     
     #TAU VETOS
     #OLD DMs
@@ -35,6 +37,8 @@ vetos = PSet(
     #ELECTRON VETOS
     eVetoMVAIsoVtx = 'vetoElectrons(0.4, "pt > 10 & abs(eta) < 2.5 & userInt(\'mvaidwp\') > 0.5 & ((userIso(0) + max(userIso(1) + neutralHadronIso - 0.5*userIso(2), 0))/pt) < 0.3 & userFloat(\'dz\') < 0.2").size()',
     eVetoMVAIso = 'vetoElectrons(0.4, "pt > 10 & abs(eta) < 2.5 & userInt(\'mvaidwp\') > 0.5 & (userIso(0) + max(userIso(1) + neutralHadronIso - 0.5*userIso(2), 0))/pt < 0.3").size()',
+    eVetoWZ = 'vetoElectrons(0.4, "userFloat(\'CBIDLoose\')>0.5 & pt > 10 & abs(eta) < 2.5").size()',
+    eVetoWZIso = 'vetoElectrons(0.4, "userFloat(\'CBIDLoose\')>0.5 & pt > 10 & abs(eta) < 2.5 & (chargedHadronIso()+max(0.0,neutralHadronIso()+photonIso()-userFloat(\'rhoCSA14\')*userFloat(\'EffectiveArea_HZZ4l2015\')))/pt() < 0.2").size()',
     
     #B-JET Vetos
     bjetCISVVeto20 = 'vetoJets(0.4, "pt > 20 & abs(eta) < 2.4 & bDiscriminator(\'combinedInclusiveSecondaryVertexV2BJetTags\') > 0.679").size()',

--- a/NtupleTools/python/templates/event.py
+++ b/NtupleTools/python/templates/event.py
@@ -42,33 +42,25 @@ pv_info = PSet(
 )
 
 met = PSet(
-    mva_metEt     = 'evt.met("mvamet").et',
-    mva_metPhi    = 'evt.met("mvamet").phi',
-    #type1_pfMetEt  = 'evt.met("pfmet").userCand("type1").et',
-    #type1_pfMetPhi = 'evt.met("pfmet").userCand("type1").phi',
-    pfMetEt  = 'evt.met4vector("pfmet","",1).Et',
-    pfMetPhi = 'evt.met4vector("pfmet","",1).phi',
-    type1_pfMetEt  = 'evt.met4vector("pfmet","type1",1).Et', #1 --> Apply phi correction
-    type1_pfMetPhi = 'evt.met4vector("pfmet","type1",1).phi',
+    mvaMetEt       = 'evt.met("mvamet").et',
+    mvaMetPhi      = 'evt.met("mvamet").phi',
+    pfMetEt        = 'evt.met4vector("pfmet","",1).Et',
+    pfMetPhi       = 'evt.met4vector("pfmet","",1).Phi',
+    type1_pfMetEt  = 'evt.met4vector("pfmet","type1",1).Et', #1 --> phi correction not in miniAOD
+    type1_pfMetPhi = 'evt.met4vector("pfmet","type1",1).Phi',
     #systematics
     pfMet_mes_Et   = 'evt.met4vector("pfmet","mes+", 1).Et',
     pfMet_tes_Et   = 'evt.met4vector("pfmet","tes+", 1).Et',
     pfMet_jes_Et   = 'evt.met4vector("pfmet","jes+", 1).Et',
     pfMet_ues_Et   = 'evt.met4vector("pfmet","ues+", 1).Et',
 
-    pfMet_mes_Phi  = 'evt.met4vector("pfmet","mes+", 1).phi',
-    pfMet_tes_Phi  = 'evt.met4vector("pfmet","tes+", 1).phi',
-    pfMet_jes_Phi  = 'evt.met4vector("pfmet","jes+", 1).phi',
-    pfMet_ues_Phi  = 'evt.met4vector("pfmet","ues+", 1).phi',
+    pfMet_mes_Phi  = 'evt.met4vector("pfmet","mes+", 1).Phi',
+    pfMet_tes_Phi  = 'evt.met4vector("pfmet","tes+", 1).Phi',
+    pfMet_jes_Phi  = 'evt.met4vector("pfmet","jes+", 1).Phi',
+    pfMet_ues_Phi  = 'evt.met4vector("pfmet","ues+", 1).Phi',
     
-    #metSignificance='evt.metSignificance',
     recoilDaught='getDaughtersRecoil().R()',
     recoilWithMet='getDaughtersRecoilWithMet().R()',
-    #does not seem to work, investigating...
-    #recoilWMetSig ='getRecoilWithMetSignificance()',
-    #mvametEt='evt.met("mvamet").et',
-    #mvametPhi='evt.met("mvamet").phi',
-    #mvametSignificance='evt.met("mvamet").significance',
 )
 
 gen = PSet(

--- a/NtupleTools/test/make_ntuples_cfg.py
+++ b/NtupleTools/test/make_ntuples_cfg.py
@@ -60,6 +60,10 @@ import PhysicsTools.PatAlgos.tools.helpers as helpers
 
 process = cms.Process("Ntuples")
 
+process.options = cms.untracked.PSet(
+    allowUnscheduled = cms.untracked.bool(True)
+)
+
 import FinalStateAnalysis.Utilities.TauVarParsing as TauVarParsing
 options = TauVarParsing.TauVarParsing(
     skipEvents=0,  # Start at an event offset (for debugging)
@@ -184,26 +188,9 @@ if options.rerunFSA:
     print 'Using globalTag: %s' % process.GlobalTag.globaltag
 
     if options.useMiniAOD:
-        mvamet_collection = 'slimmedMETs'
+        mvamet_collection = 'pfMVAMEt'
     else:
         mvamet_collection = 'systematicsMETMVA'
-
-    # Make a version with the MVA MET reconstruction method
-    # Works only if we rerun the FSA!
-    if options.rerunMVAMET:
-        process.load("FinalStateAnalysis.PatTools.met.mvaMetOnPatTuple_cff")
-        if options.useMiniAOD:
-            process.isotaus.src = "slimmedTaus"
-            mvamet_collection = "slimmedMETs"
-        else:
-            process.isotaus.src = "cleanPatTaus"
-            mvamet_collection = "patMEtMVA"
-        if not options.isMC:
-            process.patMEtMVA.addGenMET = False
-        process.mvaMetPath = cms.Path(process.pfMEtMVAsequence)
-        process.schedule.append(process.mvaMetPath)
-        print "rerunning MVA MET sequence, output collection will be {n}"\
-            .format(n=mvamet_collection)
 
     # Drop the input ones, just to make sure we aren't screwing anything up
     process.buildFSASeq = cms.Sequence()
@@ -462,6 +449,7 @@ if options.rerunFSA:
             )
         process.schedule.append(process.rhoEmbedding)
 
+        # embed info about nearest jet
         process.miniAODElectronJetInfoEmbedding = cms.EDProducer(
             "MiniAODElectronJetInfoEmbedder",
             src = cms.InputTag(fs_daughter_inputs['electrons']),
@@ -498,6 +486,46 @@ if options.rerunFSA:
             process.miniAODTauJetInfoEmbedding
         )
         process.schedule.append(process.jetInfoEmbedding)
+
+        # mvamet
+        process.load("RecoJets.JetProducers.ak4PFJets_cfi")
+        process.ak4PFJets.src = cms.InputTag("packedPFCandidates")
+        process.ak4PFJets.doAreaFastjet = cms.bool(True)
+        
+        from JetMETCorrections.Configuration.DefaultJEC_cff import ak4PFJetsL1FastL2L3
+
+        process.load("RecoMET.METPUSubtraction.mvaPFMET_cff")
+        process.pfMVAMEt.srcPFCandidates = cms.InputTag("packedPFCandidates")
+        process.pfMVAMEt.srcVertices = cms.InputTag("offlineSlimmedPrimaryVertices")
+        process.pfMVAMEt.inputFileNames.U     = cms.FileInPath('RecoMET/METPUSubtraction/data/gbrmet_7_2_X_MINIAOD_BX25PU20_Mar2015.root')
+        process.pfMVAMEt.inputFileNames.DPhi  = cms.FileInPath('RecoMET/METPUSubtraction/data/gbrphi_7_2_X_MINIAOD_BX25PU20_Mar2015.root')
+        process.pfMVAMEt.inputFileNames.CovU1 = cms.FileInPath('RecoMET/METPUSubtraction/data/gbru1cov_7_2_X_MINIAOD_BX25PU20_Mar2015.root')
+        process.pfMVAMEt.inputFileNames.CovU2 = cms.FileInPath('RecoMET/METPUSubtraction/data/gbru2cov_7_2_X_MINIAOD_BX25PU20_Mar2015.root')
+        if not options.use25ns:
+            process.pfMVAMEt.inputFileNames.U     = cms.FileInPath('RecoMET/METPUSubtraction/data/gbrmet_7_2_X_MINIAOD_BX50PU40_Jan2015.root')
+            process.pfMVAMEt.inputFileNames.DPhi  = cms.FileInPath('RecoMET/METPUSubtraction/data/gbrphi_7_2_X_MINIAOD_BX50PU40_Jan2015.root')
+            process.pfMVAMEt.inputFileNames.CovU1 = cms.FileInPath('RecoMET/METPUSubtraction/data/gbru1cov_7_2_X_MINIAOD_BX50PU40_Jan2015.root')
+            process.pfMVAMEt.inputFileNames.CovU2 = cms.FileInPath('RecoMET/METPUSubtraction/data/gbru2cov_7_2_X_MINIAOD_BX50PU40_Jan2015.root')
+        
+        process.puJetIdForPFMVAMEt.jec =  cms.string('AK4PF')
+        process.puJetIdForPFMVAMEt.vertexes = cms.InputTag("offlineSlimmedPrimaryVertices")
+        process.puJetIdForPFMVAMEt.rho = cms.InputTag("fixedGridRhoFastjetAll")
+
+        from PhysicsTools.PatAlgos.producersLayer1.metProducer_cfi import patMETs
+
+        process.miniAODMVAMEt = patMETs.clone(
+            metSource=cms.InputTag("pfMVAMEt"),
+            addMuonCorrections = cms.bool(False),
+            addGenMET = cms.bool(False)
+        )
+        fs_daughter_inputs['mvamet'] = 'miniAODMVAMEt'
+
+        output_commands.append('*_miniAODMVAMEt_*_*')
+        process.mvaMetSequence = cms.Path(
+            process.ak4PFJets *
+            process.pfMVAMEtSequence *
+            process.miniAODMVAMEt
+        )
 
         if options.hzz:
             # Make FSR photon collection, give them isolation
@@ -697,7 +725,7 @@ process.MessageLogger.cerr.UndefinedPreselectionInfo = cms.untracked.PSet(
 )
 
 if options.verbose:
-    process.options = cms.untracked.PSet(wantSummary=cms.untracked.bool(True))
+    process.options.wantSummary = cms.untracked.bool(True)
 if options.passThru:
     set_passthru(process)
 

--- a/PatTools/python/patFinalStateProducers.py
+++ b/PatTools/python/patFinalStateProducers.py
@@ -72,13 +72,6 @@ def produce_final_states(process, collections, output_commands,
         if 'extraWeights' in collections:
             process.patFinalStateEventProducer.extraWeights = collections['extraWeights']
         if useMiniAOD:
-            # first, recalculate pfMet without type1 corrections
-            #from RecoMET.METProducers.PFMET_cfi import pfMet
-            #process.pfMet = pfMet.clone(src = "packedPFCandidates")
-            #process.pfMet.calculateSignificance = False # this can't be easily implemented on packed PF candidates at the moment
-            #sequence += process.pfMet
-            # now produce the final states
-            #process.patFinalStateEventProducerMiniAOD.mets.pfmet = cms.InputTag("pfMet")
             process.patFinalStateEventProducer.miniAOD = cms.bool(True)
             process.patFinalStateEventProducer.trgSrc = cms.InputTag("selectedPatTrigger")
             process.patFinalStateEventProducer.rhoSrc = cms.InputTag('fixedGridRhoAll')
@@ -87,6 +80,7 @@ def produce_final_states(process, collections, output_commands,
             process.patFinalStateEventProducer.genParticleSrc = cms.InputTag("prunedGenParticles")
             process.patFinalStateEventProducer.mets = cms.PSet(
                 pfmet = cms.InputTag(pfmetsrc),
+                mvamet = cms.InputTag(mvametsrc)
             )
         else:
             process.patFinalStateEventProducer.mets.pfmet = pfmetsrc

--- a/recipe/recipe_13TeV.sh
+++ b/recipe/recipe_13TeV.sh
@@ -78,6 +78,13 @@ then
   #patch -N -p0 < FinalStateAnalysis/recipe/patches/PATObject.h.patch
   #set -o errexit
 
+  echo "Checking out recipe for mvamet"
+  # https://twiki.cern.ch/twiki/bin/viewauth/CMS/MVAMet#CMSSW_7_2_X_requires_slc6_MiniAO
+  git-cms-merge-topic -u cms-met:72X-13TeV-Training-30Jan15
+  pushd $CMSSW_BASE/src/RecoMET/METPUSubtraction
+  git clone https://github.com/rfriese/RecoMET-METPUSubtraction data -b 72X-13TeV-Phys14_25_V4-26Mar15
+  popd
+
 fi
 
 popd

--- a/recipe/recipe_common.sh
+++ b/recipe/recipe_common.sh
@@ -9,11 +9,10 @@ MAJOR_VERSION=`echo $CMSSW_VERSION | sed "s|CMSSW_\([0-9]\)_.*|\1|"`
 MINOR_VERSION=`echo $CMSSW_VERSION | sed "s|CMSSW_\([0-9]\)_\([0-9]\)_.*|\2|"`
 
 #for standalone version of svfit
-# cvs co -r V00-01-04s TauAnalysis/CandidateTools
-git clone https://github.com/cms-analysis/TauAnalysis-CandidateTools.git TauAnalysis/CandidateTools
-pushd $CMSSW_BASE/src/TauAnalysis/CandidateTools
-git checkout TauAnalysis-CandidateTools-V00-01-04s
-pushd $CMSSW_BASE/src
+git clone git@github.com:veelken/SVfit_standalone.git TauAnalysis/SVfitStandalone
+pushd $CMSSW_BASE/src/TauAnalysis/SVfitStandalone
+git checkout svFit_2015Mar28
+popd
 
 # Tags that work in any release
 


### PR DESCRIPTION
MVAMET implemented on miniAOD using: https://twiki.cern.ch/twiki/bin/viewauth/CMS/MVAMet#CMSSW_7_2_X_requires_slc6_MiniAO

svFit implemented using: https://twiki.cern.ch/twiki/bin/viewauth/CMS/HiggsToTauTauWorking2015#SVfit

mvaMet looks good. Don't know how to verify svFit, but it runs with option `svFit=1`.
