### PR TITLE
New parameterized make_ntuples

### DIFF
--- a/DataFormats/interface/PATFinalStateEvent.h
+++ b/DataFormats/interface/PATFinalStateEvent.h
@@ -55,7 +55,6 @@ class PATFinalStateEvent {
     // This constructor should only be used in the initial production!
     // It automatically sets the version() to the current one.
     PATFinalStateEvent(
-        bool miniAOD,
         double rho,
         const edm::Ptr<reco::Vertex>& pv,
         const edm::PtrVector<reco::Vertex>& recoVertices,
@@ -197,13 +196,9 @@ class PATFinalStateEvent {
     char version() const { return fsaDataFormatVersion_; }
     float jetVariables(const reco::CandidatePtr jet, const std::string& myvar) const;
 
-    // check if is miniAOD
-    const bool isMiniAOD() const {return miniAOD_;} 
-      
   private:
     std::map<std::string, float> weights_;
     std::map<std::string, int> flags_;
-    bool miniAOD_;
     double rho_;
     pat::TriggerEvent triggerEvent_;
     edm::RefProd<std::vector<pat::TriggerObjectStandAlone> > triggerObjects_;

--- a/DataFormats/src/PATFinalState.cc
+++ b/DataFormats/src/PATFinalState.cc
@@ -285,13 +285,7 @@ PATFinalState::visP4() const {
 PATFinalState::LorentzVector PATFinalState::totalP4(
     const std::string& tags, const std::string& metSysTag) const {
   reco::Candidate::LorentzVector output = visP4(tags);
-  if (!event_->isMiniAOD() && metSysTag != "" && metSysTag != "@") {
-    const reco::CandidatePtr& metUserCand = met()->userCand(metSysTag);
-    assert(metUserCand.isNonnull());
-    output += metUserCand->p4();
-  } else {
-    output += met()->p4();
-  }
+  output += met()->p4();
   return output;
 }
 
@@ -379,25 +373,16 @@ PATFinalState::deltaPhiToMEt(int i, const std::string& sysTag,
   double metPhi;
   if(metTag != "")
     {
-      if (event_->isMiniAOD())
-	{
-	  if(metTag == "jes+")
-	    metPhi = met()->shiftedPhi(pat::MET::JetEnUp);
-	  else if(metTag == "ues+")
-	    metPhi = met()->shiftedPhi(pat::MET::UnclusteredEnUp);
-	  else if(metTag == "tes+")
-	    metPhi = met()->shiftedPhi(pat::MET::TauEnUp);
-	  else if(metTag == "mes+")
-	    metPhi = met()->shiftedPhi(pat::MET::MuonEnUp);
-	  else // all miniAOD pfMET is Type 1
-	    metPhi = met()->phi();
-	}
-      else
-	{
-	  const reco::CandidatePtr& metUserCand = met()->userCand(metTag);
-	  assert(metUserCand.isNonnull());
-	  metPhi = metUserCand->phi();
-	}
+      if(metTag == "jes+")
+        metPhi = met()->shiftedPhi(pat::MET::JetEnUp);
+      else if(metTag == "ues+")
+        metPhi = met()->shiftedPhi(pat::MET::UnclusteredEnUp);
+      else if(metTag == "tes+")
+        metPhi = met()->shiftedPhi(pat::MET::TauEnUp);
+      else if(metTag == "mes+")
+        metPhi = met()->shiftedPhi(pat::MET::MuonEnUp);
+      else // all miniAOD pfMET is Type 1
+        metPhi = met()->phi();
     }
   else
     metPhi = met()->phi();
@@ -413,25 +398,16 @@ PATFinalState::twoParticleDeltaPhiToMEt(const int i, const int j, const std::str
   double metPhi;
   if(metTag != "")
     {
-      if(event_->isMiniAOD())
-	{
-	  if(metTag == "jes+")
-	    metPhi = met()->shiftedPhi(pat::MET::JetEnUp);
-	  else if(metTag == "ues+")
-	    metPhi = met()->shiftedPhi(pat::MET::UnclusteredEnUp);
-	  else if(metTag == "tes+")
-	    metPhi = met()->shiftedPhi(pat::MET::TauEnUp);
-	  else if(metTag == "mes+")
-	    metPhi = met()->shiftedPhi(pat::MET::MuonEnUp);
-	  else // all miniAOD pfMET is Type 1
-	    metPhi = met()->phi();
-	}
-      else
-	{
-	  const reco::CandidatePtr& metUserCand = met()->userCand(metTag);
-	  assert(metUserCand.isNonnull());
-	  metPhi = metUserCand->phi();
-	}
+      if(metTag == "jes+")
+        metPhi = met()->shiftedPhi(pat::MET::JetEnUp);
+      else if(metTag == "ues+")
+        metPhi = met()->shiftedPhi(pat::MET::UnclusteredEnUp);
+      else if(metTag == "tes+")
+        metPhi = met()->shiftedPhi(pat::MET::TauEnUp);
+      else if(metTag == "mes+")
+        metPhi = met()->shiftedPhi(pat::MET::MuonEnUp);
+      else // all miniAOD pfMET is Type 1
+        metPhi = met()->phi();
     }
   else
     metPhi = met()->phi();
@@ -460,27 +436,16 @@ PATFinalState::mt(int i, int j) const {
 double PATFinalState::mtMET(int i, const std::string& tag,
     const std::string& metTag) const {
   reco::Candidate::LorentzVector metP4;
-  if(event_->isMiniAOD())
-    {
-      if(metTag == "jes+")
-	metP4 = met()->shiftedP4(pat::MET::JetEnUp);
-      else if(metTag == "ues+")
-	metP4 = met()->shiftedP4(pat::MET::UnclusteredEnUp);
-      else if(metTag == "tes+")
-	metP4 = met()->shiftedP4(pat::MET::TauEnUp);
-      else if(metTag == "mes+")
-	metP4 = met()->shiftedP4(pat::MET::MuonEnUp);
-      else // all miniAOD pfMET is Type 1
-	metP4 = met()->p4();
-    }
-  else if (metTag != "") 
-    {
-      metP4 = met()->userCand(metTag)->p4();
-    } 
-  else 
-    {
-      metP4 = met()->p4();
-    }
+  if(metTag == "jes+")
+    metP4 = met()->shiftedP4(pat::MET::JetEnUp);
+  else if(metTag == "ues+")
+    metP4 = met()->shiftedP4(pat::MET::UnclusteredEnUp);
+  else if(metTag == "tes+")
+    metP4 = met()->shiftedP4(pat::MET::TauEnUp);
+  else if(metTag == "mes+")
+    metP4 = met()->shiftedP4(pat::MET::MuonEnUp);
+  else // all miniAOD pfMET is Type 1
+    metP4 = met()->p4();
   return fshelpers::transverseMass(daughterUserCandP4(i, tag), metP4);
 }
 
@@ -491,10 +456,7 @@ double PATFinalState::mtMET(int i, const std::string& metTag) const {
 double PATFinalState::mtMET(int i, const std::string& tag,
 			    const std::string& metName, const std::string& metTag, 
 			    const int applyPhiCorr) const {
-  if(event_->isMiniAOD())
-    return mtMET(i, tag, metTag);
-  return fshelpers::transverseMass(daughterUserCandP4(i, tag),
-				   evt()->met4vector(metName, metTag, applyPhiCorr));
+  return mtMET(i, tag, metTag);
 }
 
 double PATFinalState::ht(const std::string& sysTags) const {
@@ -663,27 +625,9 @@ PATFinalState::subcandfsr( int i, int j, const std::string& fsrLabel ) const
   output.push_back( daughterPtr(i) );
   output.push_back( daughterPtr(j) );
   
-  if(evt()->isMiniAOD())
-    {
-      const reco::CandidatePtr fsrPho = bestFSROfZ(i, j, fsrLabel);
-      if(fsrPho.isNonnull() && fsrPho.isAvailable())
-	{
-	  output.push_back(fsrPho);
-	}
-    }
-  else
-    {
-      std::stringstream ss;
-      ss << "fsrPhoton" << i << j;
-      std::string photon_name = ss.str();
-
-      const std::vector<std::string>& userCandList = this->userCandNames();
-      for (size_t i = 0; i < userCandList.size(); ++i)
-	{
-	  if (userCandList[i].find(photon_name) != std::string::npos)
-	    output.push_back(this->userCand(userCandList[i]));
-	}
-    }
+  const reco::CandidatePtr fsrPho = bestFSROfZ(i, j, fsrLabel);
+  if(fsrPho.isNonnull() && fsrPho.isAvailable())
+    output.push_back(fsrPho);
   return PATFinalStateProxy(new PATMultiCandFinalState(output, evt()));
 }
 
@@ -792,71 +736,50 @@ const reco::CandidatePtr PATFinalState::bestFSROfZ(int i, int j, const std::stri
 PATFinalState::LorentzVector
 PATFinalState::p4fsr(const std::string& fsrLabel) const
 {
-  if(evt()->isMiniAOD())
+  PATFinalStateProxy bestZ;
+  int bestL1 = 0;
+  int bestL2 = 1;
+  
+  for(int lep1 = 0; lep1 < 3; ++lep1)
     {
-      PATFinalStateProxy bestZ;
-      int bestL1 = 0;
-      int bestL2 = 1;
-      
-      for(int lep1 = 0; lep1 < 3; ++lep1)
-	{
-	  for(int lep2 = lep1 + 1; lep2 <= 3; ++lep2)
-	    {
-	      PATFinalStateProxy cand = subcandfsr(lep1,lep2,fsrLabel);
-	      if(lep1 == 0 && lep2 == 1) // no best Z yet
-		{
-		  bestZ = cand;
-		  continue;
-		}
-	      
-	      if(zCompatibility(cand) < zCompatibility(bestZ))
-		{
-		  bestZ = cand;
-		  bestL1 = lep1;
-		  bestL2 = lep2;
-		  continue;
-		}
-	    }
-	}
-
-      int otherL1 = -1;
-      int otherL2 = -1;
-      for(int foo = 0; foo < 4; ++foo)
-	{
-	  if(foo != bestL1 && foo != bestL2)
-	    {
-	      if(otherL1 == -1)
-		{
-		  otherL1 = foo;
-		}
-	      else
-		{
-		  otherL2 = foo;
-		}
-	    }
-	}
-      PATFinalStateProxy otherZ = subcandfsr(otherL1, otherL2, fsrLabel);
-
-      return bestZ->p4() + otherZ->p4();
+      for(int lep2 = lep1 + 1; lep2 <= 3; ++lep2)
+        {
+          PATFinalStateProxy cand = subcandfsr(lep1,lep2,fsrLabel);
+          if(lep1 == 0 && lep2 == 1) // no best Z yet
+    	{
+    	  bestZ = cand;
+    	  continue;
+    	}
+          
+          if(zCompatibility(cand) < zCompatibility(bestZ))
+    	{
+    	  bestZ = cand;
+    	  bestL1 = lep1;
+    	  bestL2 = lep2;
+    	  continue;
+    	}
+        }
     }
-  else
+
+  int otherL1 = -1;
+  int otherL2 = -1;
+  for(int foo = 0; foo < 4; ++foo)
     {
-      PATFinalState::LorentzVector p4_out;
-
-      p4_out = daughter(0)->p4() + daughter(1)->p4() + daughter(2)->p4() + daughter(3)->p4();
-
-      const std::vector<std::string>& userCandList = this->userCandNames();
-      for (size_t i = 0; i < userCandList.size(); ++i)
-	{
-	  if (userCandList[i].find("fsrPhoton1") != std::string::npos)
-	    p4_out += this->userCand(userCandList[i])->p4();
-
-	  if (userCandList[i].find("fsrPhoton2") != std::string::npos)
-	    p4_out += this->userCand(userCandList[i])->p4();
-	}
-
-      return p4_out;
+      if(foo != bestL1 && foo != bestL2)
+        {
+          if(otherL1 == -1)
+    	{
+    	  otherL1 = foo;
+    	}
+          else
+    	{
+    	  otherL2 = foo;
+    	}
+        }
     }
+  PATFinalStateProxy otherZ = subcandfsr(otherL1, otherL2, fsrLabel);
+
+  return bestZ->p4() + otherZ->p4();
 }
 
 PATFinalStateProxy
@@ -1080,120 +1003,92 @@ const float PATFinalState::jetVariables(size_t i, const std::string& key) const 
 
 const float PATFinalState::getIP3D(const size_t i) const
 {
-  if(event_->isMiniAOD())
+  if(abs(daughter(i)->pdgId()) == 11)
     {
-      if(abs(daughter(i)->pdgId()) == 11)
-	{
-	  return fabs(daughterAsElectron(i)->dB(pat::Electron::PV3D));
-	}
-      else if (abs(daughter(i)->pdgId()) == 13)
-	{
-	  return fabs(daughterAsMuon(i)->dB(pat::Muon::PV3D));
-	}
-      
-      throw cms::Exception("InvalidParticle") << "FSA can only find SIP3D for electron and muon for now" << std::endl;
+      return fabs(daughterAsElectron(i)->dB(pat::Electron::PV3D));
     }
-
-  return dynamic_cast<const pat::PATObject<reco::Candidate>* >(daughter(i))->userFloat("ip3D");
+  else if (abs(daughter(i)->pdgId()) == 13)
+    {
+      return fabs(daughterAsMuon(i)->dB(pat::Muon::PV3D));
+    }
+  
+  throw cms::Exception("InvalidParticle") << "FSA can only find SIP3D for electron and muon for now" << std::endl;
 }
 
 const float PATFinalState::getIP3DErr(const size_t i) const
 {
-  if(event_->isMiniAOD())
+  if(abs(daughter(i)->pdgId()) == 11)
     {
-      if(abs(daughter(i)->pdgId()) == 11)
-	{
-	  return daughterAsElectron(i)->edB(pat::Electron::PV3D);
-	}
-      else if (abs(daughter(i)->pdgId()) == 13)
-	{
-	  return daughterAsMuon(i)->edB(pat::Muon::PV3D);
-	}
-      
-      throw cms::Exception("InvalidParticle") << "FSA can only find SIP3D for electron and muon for now" << std::endl;
+      return daughterAsElectron(i)->edB(pat::Electron::PV3D);
     }
-
-return static_cast<const pat::PATObject<reco::Candidate> *>(daughter(i))->userFloat("ip3DS");
+  else if (abs(daughter(i)->pdgId()) == 13)
+    {
+      return daughterAsMuon(i)->edB(pat::Muon::PV3D);
+    }
+  
+  throw cms::Exception("InvalidParticle") << "FSA can only find SIP3D for electron and muon for now" << std::endl;
 }
 
 const float PATFinalState::getIP2D(const size_t i) const
 {
-  if(event_->isMiniAOD())
+  if(abs(daughter(i)->pdgId()) == 11)
     {
-      if(abs(daughter(i)->pdgId()) == 11)
-	{
-	  return fabs(daughterAsElectron(i)->dB(pat::Electron::PV2D));
-	}
-      else if (abs(daughter(i)->pdgId()) == 13)
-	{
-	  return fabs(daughterAsMuon(i)->dB(pat::Muon::PV2D));
-	}
-      
-      throw cms::Exception("InvalidParticle") << "FSA can only find SIP3D for electron and muon for now" << std::endl;
+      return fabs(daughterAsElectron(i)->dB(pat::Electron::PV2D));
     }
-
-  return dynamic_cast<const pat::PATObject<reco::Candidate>* >(daughter(i))->userFloat("ip3D");
+  else if (abs(daughter(i)->pdgId()) == 13)
+    {
+      return fabs(daughterAsMuon(i)->dB(pat::Muon::PV2D));
+    }
+  
+  throw cms::Exception("InvalidParticle") << "FSA can only find SIP3D for electron and muon for now" << std::endl;
 }
 
 const float PATFinalState::getIP2DErr(const size_t i) const
 {
-  if(event_->isMiniAOD())
+  if(abs(daughter(i)->pdgId()) == 11)
     {
-      if(abs(daughter(i)->pdgId()) == 11)
-	{
-	  return daughterAsElectron(i)->edB(pat::Electron::PV2D);
-	}
-      else if (abs(daughter(i)->pdgId()) == 13)
-	{
-	  return daughterAsMuon(i)->edB(pat::Muon::PV2D);
-	}
-      
-      throw cms::Exception("InvalidParticle") << "FSA can only find SIP2D for electron and muon for now" << std::endl;
+      return daughterAsElectron(i)->edB(pat::Electron::PV2D);
     }
-
-return static_cast<const pat::PATObject<reco::Candidate> *>(daughter(i))->userFloat("ip3DS");
+  else if (abs(daughter(i)->pdgId()) == 13)
+    {
+      return daughterAsMuon(i)->edB(pat::Muon::PV2D);
+    }
+  
+  throw cms::Exception("InvalidParticle") << "FSA can only find SIP2D for electron and muon for now" << std::endl;
 }
 
 const float PATFinalState::getPVDZ(const size_t i) const
 {
-  if(event_->isMiniAOD())
+  if(abs(daughter(i)->pdgId()) == 11)
     {
-      if(abs(daughter(i)->pdgId()) == 11)
-	{
-	  const edm::Ptr<reco::Vertex> pv = event_->pv();
-	  return daughterAsElectron(i)->gsfTrack()->dz(pv->position());
-	}
-      else if(abs(daughter(i)->pdgId()) == 13)
-	{
-	  const edm::Ptr<reco::Vertex> pv = event_->pv();
-	  return daughterAsMuon(i)->innerTrack()->dz(pv->position());
-	}
-      throw cms::Exception("InvalidParticle") << "FSA can only find dZ for electron and muon for now" << std::endl;
+      const edm::Ptr<reco::Vertex> pv = event_->pv();
+      return daughterAsElectron(i)->gsfTrack()->dz(pv->position());
     }
-  return dynamic_cast<const pat::PATObject<reco::Candidate> *>(daughter(i))->userFloat("dz");
+  else if(abs(daughter(i)->pdgId()) == 13)
+    {
+      const edm::Ptr<reco::Vertex> pv = event_->pv();
+      return daughterAsMuon(i)->innerTrack()->dz(pv->position());
+    }
+  throw cms::Exception("InvalidParticle") << "FSA can only find dZ for electron and muon for now" << std::endl;
 }
 
 const float PATFinalState::getPVDXY(const size_t i) const
 {
-  if(event_->isMiniAOD())
+  if(abs(daughter(i)->pdgId()) == 11)
     {
-      if(abs(daughter(i)->pdgId()) == 11)
-	{
-	  const edm::Ptr<reco::Vertex> pv = event_->pv();
-	  return daughterAsElectron(i)->gsfTrack()->dxy(pv->position());
-	}
-      else if(abs(daughter(i)->pdgId()) == 13)
-	{
-	  const edm::Ptr<reco::Vertex> pv = event_->pv();
-	  return daughterAsMuon(i)->innerTrack()->dxy(pv->position());
-	}
-      else if(abs(daughter(i)->pdgId()) == 15)
-	{
-	  return daughterAsTau(i)->dxy();
-	}
-      throw cms::Exception("InvalidParticle") << "FSA can only find dXY for electron, muon, and tau for now" << std::endl;
+      const edm::Ptr<reco::Vertex> pv = event_->pv();
+      return daughterAsElectron(i)->gsfTrack()->dxy(pv->position());
     }
-  return dynamic_cast<const pat::PATObject<reco::Candidate> *>(daughter(i))->userFloat("ipDXY");
+  else if(abs(daughter(i)->pdgId()) == 13)
+    {
+      const edm::Ptr<reco::Vertex> pv = event_->pv();
+      return daughterAsMuon(i)->innerTrack()->dxy(pv->position());
+    }
+  else if(abs(daughter(i)->pdgId()) == 15)
+    {
+      return daughterAsTau(i)->dxy();
+    }
+  throw cms::Exception("InvalidParticle") << "FSA can only find dXY for electron, muon, and tau for now" << std::endl;
 }
 
 const bool PATFinalState::isTightMuon(const size_t i) const

--- a/DataFormats/src/PATFinalStateEvent.cc
+++ b/DataFormats/src/PATFinalStateEvent.cc
@@ -54,7 +54,6 @@ PATFinalStateEvent::PATFinalStateEvent(
   met_(met) { }
 
 PATFinalStateEvent::PATFinalStateEvent(
-    bool miniAOD,
     double rho,
     const edm::Ptr<reco::Vertex>& pv,
     const edm::PtrVector<reco::Vertex>& recoVertices,
@@ -84,7 +83,6 @@ PATFinalStateEvent::PATFinalStateEvent(
     const reco::GsfTrackRefProd& gsfTracks,
     const std::map<std::string, edm::Ptr<pat::MET> >& mets
     ):
-  miniAOD_(miniAOD),
   rho_(rho),
   triggerEvent_(triggerEvent),
   triggerObjects_(triggerObjects),
@@ -208,47 +206,39 @@ const edm::EventID& PATFinalStateEvent::evtId() const {
 
 // Superseded by the smart trigger
 int PATFinalStateEvent::hltResult(const std::string& pattern) const {
-  SmartTriggerResult result = miniAOD_ ? smartTrigger(pattern, names(), trigPrescale(), trigResults(), evtID_) : 
-    smartTrigger(pattern, trig(), evtID_);
+  SmartTriggerResult result = smartTrigger(pattern, names(), trigPrescale(), trigResults(), evtID_);
   return result.passed;
 }
 
 int PATFinalStateEvent::hltPrescale(const std::string& pattern) const {
-  SmartTriggerResult result = miniAOD_ ? smartTrigger(pattern, names(), trigPrescale(), trigResults(), evtID_) : 
-    smartTrigger(pattern, trig(), evtID_);
+  SmartTriggerResult result = smartTrigger(pattern, names(), trigPrescale(), trigResults(), evtID_);
   return result.prescale;
 }
 
 int PATFinalStateEvent::hltGroup(const std::string& pattern) const {
-  SmartTriggerResult result = miniAOD_ ? smartTrigger(pattern, names(), trigPrescale(), trigResults(), evtID_) : 
-    smartTrigger(pattern, trig(), evtID_);
+  SmartTriggerResult result = smartTrigger(pattern, names(), trigPrescale(), trigResults(), evtID_);
   return result.group;
 }
 
 int PATFinalStateEvent::matchedToFilter(const reco::Candidate& cand,
     const std::string& pattern, double maxDeltaR) const {
-  std::vector<const pat::TriggerFilter*> filters = miniAOD_ ?
-    matchingTriggerFilters(trigStandAlone(), names(), pattern) :
-    matchingTriggerFilters(trig(), pattern);
+  std::vector<const pat::TriggerFilter*> filters = matchingTriggerFilters(trigStandAlone(), names(), pattern);
   if (!filters.size())
     return -1;
-  return miniAOD_ ? matchedToAnObject(trigStandAlone(), cand, maxDeltaR) :
-    matchedToAnObject(triggerEvent_.filterObjects(filters[0]->label()), cand, maxDeltaR);
+  return matchedToAnObject(trigStandAlone(), cand, maxDeltaR);
 }
 
 int PATFinalStateEvent::matchedToPath(const reco::Candidate& cand,
     const std::string& pattern, double maxDeltaR) const {
   // std::cout << "matcher: " << pattern << std::endl;
-  SmartTriggerResult result = miniAOD_ ? smartTrigger(pattern, names(), trigPrescale(), trigResults(), evtID_) : 
-    smartTrigger(pattern, trig(), evtID_);
+  SmartTriggerResult result = smartTrigger(pattern, names(), trigPrescale(), trigResults(), evtID_);
   //std::cout << " result: " << result.group << " " << result.prescale << " " << result.passed << std::endl;
   // Loop over all the paths that fired and see if any matched this object.
   if (!result.passed)
     return -1;
   int matchCount = 0;
   for (size_t i = 0; i < result.paths.size(); ++i) {
-    bool matched = miniAOD_ ? matchedToAnObject(trigStandAlone(), cand, maxDeltaR) :
-      matchedToAnObject(triggerEvent_.pathObjects(result.paths[i]), cand, maxDeltaR);
+    bool matched = matchedToAnObject(trigStandAlone(), cand, maxDeltaR);
     // std::cout << " - path: " << result.paths[i] << " matched: " << matched << std::endl;
     if (matched)
       matchCount += 1;

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -37,7 +37,8 @@
    <version ClassVersion="10" checksum="4038526841"/>
   </class>
 
-  <class name="PATFinalStateEvent" ClassVersion="15">
+  <class name="PATFinalStateEvent" ClassVersion="16">
+   <version ClassVersion="16" checksum="178010298"/>
    <version ClassVersion="15" checksum="1840019056"/>
    <version ClassVersion="14" checksum="1619979458"/>
    <version ClassVersion="13" checksum="3775954220"/>

--- a/NtupleTools/python/embedElectronIDs.py
+++ b/NtupleTools/python/embedElectronIDs.py
@@ -1,0 +1,76 @@
+# Embed IDs for electrons
+
+def embedElectronIDs(process,use25ns,eSrc):
+    # Turn on versioned cut-based ID
+    from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
+    process.load("RecoEgamma.ElectronIdentification.egmGsfElectronIDs_cfi")
+    process.egmGsfElectronIDs.physicsObjectSrc = cms.InputTag(eSrc)
+    from PhysicsTools.SelectorUtils.centralIDRegistry import central_id_registry
+    process.egmGsfElectronIDSequence = cms.Sequence(process.egmGsfElectronIDs)
+    if use25ns:
+        cb_id_modules = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_PHYS14_PU20bx25_V1_miniAOD_cff']
+    else:
+        print "50 ns cut based electron IDs don't exist yet for PHYS14. Using CSA14 cuts."
+        cb_id_modules = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_CSA14_50ns_V1_cff']
+    for idmod in cb_id_modules:
+        setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
+    
+    CBIDLabels = ["CBIDVeto", "CBIDLoose", "CBIDMedium", "CBIDTight"] # keys of cut based id user floats
+    if use25ns:
+        CBIDTags = [
+            cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V1-miniAOD-standalone-veto'),
+            cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V1-miniAOD-standalone-loose'),
+            cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V1-miniAOD-standalone-medium'),
+            cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-PHYS14-PU20bx25-V1-miniAOD-standalone-tight'),
+            ]
+    else:
+        CBIDTags = [ # almost certainly wrong. Just don't use 50ns miniAOD any more
+            cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-CSA14-50ns-V1-standalone-veto'),
+            cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-CSA14-50ns-V1-standalone-loose'),
+            cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-CSA14-50ns-V1-standalone-medium'),
+            cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-CSA14-50ns-V1-standalone-tight'),
+            ]
+    
+    # Embed cut-based VIDs
+    process.miniAODElectronCutBasedID = cms.EDProducer(
+        "MiniAODElectronCutBasedIDEmbedder",
+        src=cms.InputTag(eSrc),
+        idLabels = cms.vstring(*CBIDLabels),
+        ids = cms.VInputTag(*CBIDTags)
+    )
+    eSrc = "miniAODElectronCutBasedID"
+    
+    # Embed MVA VIDs (weights will change soon for PHYS14!)
+    trigMVAWeights = [
+        'EgammaAnalysis/ElectronTools/data/CSA14/TrigIDMVA_25ns_EB_BDT.weights.xml',
+        'EgammaAnalysis/ElectronTools/data/CSA14/TrigIDMVA_25ns_EE_BDT.weights.xml',
+        ]
+    nonTrigMVAWeights = [
+        'EgammaAnalysis/ElectronTools/data/PHYS14/EIDmva_EB1_5_oldscenario2phys14_BDT.weights.xml',
+        'EgammaAnalysis/ElectronTools/data/PHYS14/EIDmva_EB2_5_oldscenario2phys14_BDT.weights.xml',
+        'EgammaAnalysis/ElectronTools/data/PHYS14/EIDmva_EE_5_oldscenario2phys14_BDT.weights.xml',
+        'EgammaAnalysis/ElectronTools/data/PHYS14/EIDmva_EB1_10_oldscenario2phys14_BDT.weights.xml',
+        'EgammaAnalysis/ElectronTools/data/PHYS14/EIDmva_EB2_10_oldscenario2phys14_BDT.weights.xml',
+        'EgammaAnalysis/ElectronTools/data/PHYS14/EIDmva_EE_10_oldscenario2phys14_BDT.weights.xml',
+        ]
+    if not use25ns:
+        for wt in trigMVAWeights+nonTrigMVAWeights:
+            wt.replace('25ns','50ns')
+    process.miniAODElectronMVAID = cms.EDProducer(
+        "MiniAODElectronMVAIDEmbedder",
+        src=cms.InputTag(eSrc),
+        trigWeights = cms.vstring(*trigMVAWeights),
+        trigLabel = cms.string('BDTIDTrig'), # triggering MVA ID userfloat key
+        nonTrigWeights = cms.vstring(*nonTrigMVAWeights),
+        nonTrigLabel = cms.string('BDTIDNonTrig') # nontriggering MVA ID userfloat key
+        )
+    eSrc = 'miniAODElectronMVAID'
+    
+    process.miniAODElectrons = cms.Path(
+        process.egmGsfElectronIDSequence+
+        process.miniAODElectronCutBasedID+
+        process.miniAODElectronMVAID
+        )
+    process.schedule.append(process.miniAODElectrons)
+
+    return eSrc

--- a/NtupleTools/python/parameters/default.py
+++ b/NtupleTools/python/parameters/default.py
@@ -1,0 +1,51 @@
+# Default parameters to be used in production of ntuples
+# Only parameters seen here are used. make_ntuples_cfg.py loads these first
+# and then loads any modifications to these parameters from a custom param file
+# passed via paramFile=/path/to/param/file.py
+
+from FinalStateAnalysis.Utilities.cfgtools import PSet
+
+parameters = {
+    # minimal object kinematic cuts
+    'ptCuts' : {
+        'm': '5',
+        'e': '7',
+        't': '18',
+        'g': '10',
+        'j': '20'
+    },
+    'etaCuts' : {
+        'm': '2.5',
+        'e': '3.0',
+        't': '2.3',
+        'g': '3.0',
+        'j': '2.5'
+    },
+    # selections to include object in final state (should be looser than analysis selections)
+    'objectSelection' : {
+        'e': 'abs(superCluster().eta) < 3.0 & max(pt, userFloat("maxCorPt")) > 7',
+        'm': 'max(pt, userFloat("maxCorPt")) > 4 & (isGlobalMuon | isTrackerMuon)',
+        't': 'abs(eta) < 2.5 & pt > 17 & tauID("decayModeFinding")',
+        'g': 'abs(superCluster().eta()) < 3.0 & pt > 10',
+        'j': 'pt>20 & abs(eta) < 2.5 & userFloat("idLoose")'
+    },
+    # selections to clean jets
+    'jetCleaningSelections' : {
+        'e': 'pt>10&&userInt("CBIDVeto")>0&&(userIso(0)+max(userIso(1)+neutralHadronIso()-0.5*userIso(2),0.0))/pt()<0.3',
+        'm': 'pt>10&&isGlobalMuon&&isTrackerMuon&&(userIso(0)+max(photonIso()+neutralHadronIso()-0.5*puChargedHadronIso(),0))/pt()<0.3',
+    },
+    'jetDeltaRCleaning' : 0.3,
+    # cross cleaning for objects in final state
+    'crossCleaning' : 'smallestDeltaR() > 0.3',
+    # additional variables for ntuple
+    'eventVariables' : PSet(),
+    # candidates of form: objectVarName = 'string expression for selection'
+    'candidateVariables' : PSet(),
+    'electronVariables' : PSet(),
+    'muonVariables' : PSet(),
+    'tauVariables' : PSet(),
+    'photonVariables' : PSet(),
+    'jetVariables' : PSet(),
+    # dicandidates of form: object1_object2_VarName = 'string expression for candidate'
+    'dicandidateVariables' : PSet(),
+}

--- a/NtupleTools/python/parameters/wz.py
+++ b/NtupleTools/python/parameters/wz.py
@@ -1,0 +1,56 @@
+# Default parameters to be used in production of ntuples
+# Only parameters seen here are used. make_ntuples_cfg.py loads these first
+# and then loads any modifications to these parameters from a custom param file
+# passed via paramFile=/path/to/param/file.py
+
+from FinalStateAnalysis.Utilities.cfgtools import PSet
+
+parameters = {
+    # minimal object kinematic cuts
+    'ptCuts' : {
+        'm': '5',
+        'e': '7',
+        't': '18',
+        'g': '10',
+        'j': '20'
+    },
+    'etaCuts' : {
+        'm': '2.5',
+        'e': '3.0',
+        't': '2.3',
+        'g': '3.0',
+        'j': '2.5'
+    },
+    # selections to include object in final state (should be looser than analysis selections)
+    'objectSelection' : {
+        'e': 'abs(superCluster().eta) < 3.0 & max(pt, userFloat("maxCorPt")) > 7',
+        'm': 'max(pt, userFloat("maxCorPt")) > 4 & (isGlobalMuon | isTrackerMuon)',
+        't': 'abs(eta) < 2.5 & pt > 17 & tauID("decayModeFinding")',
+        'g': 'abs(superCluster().eta()) < 3.0 & pt > 10',
+        'j': 'pt>20 & abs(eta) < 2.5 & userFloat("idLoose")'
+    },
+    # selections to clean jets
+    'jetCleaningSelections' : {
+        'e': 'pt>10&&userInt("CBIDLoose")>0&&(chargedHadronIso()+max(0.0,neutralHadronIso()+photonIso()-userFloat("rhoCSA14")*userFloat("EffectiveArea_HZZ4l2015")))/pt()<0.2',
+        'm': 'pt>10&&isLooseMuon&&(chargedHadronIso()+max(photonIso()+neutralHadronIso()-0.5*puChargedHadronIso,0.0))/pt()<0.2',
+    },
+    'jetDeltaRCleaning' : 0.3,
+    # cross cleaning for objects in final state
+    'crossCleaning' : '',
+    # additional variables for ntuple
+    'eventVariables' : PSet(
+        muVeto = 'vetoMuons(0.4, "isLooseMuon & pt > 10 & abs(eta) < 2.4").size()',
+        muVetoIso = 'vetoMuons(0.4, "isLooseMuon & pt > 10 & abs(eta) < 2.4 & (chargedHadronIso()+max(0.0,neutralHadronIso()+photonIso()-userFloat(\'rhoCSA14\')*userFloat(\'EffectiveArea_HZZ4l2015\')))/pt()<0.2").size()',
+        eVeto = 'vetoElectrons(0.4, "userFloat(\'CBIDLoose\')>0.5 & pt > 10 & abs(eta) < 2.5").size()',
+        eVetoIso = 'vetoElectrons(0.4, "userFloat(\'CBIDLoose\')>0.5 & pt > 10 & abs(eta) < 2.5 & (chargedHadronIso()+max(0.0,neutralHadronIso()+photonIso()-userFloat(\'rhoCSA14\')*userFloat(\'EffectiveArea_HZZ4l2015\')))/pt() < 0.2").size()',
+    ),
+    # candidates of form: objectVarName = 'string expression for selection'
+    'candidateVariables' : PSet(),
+    'electronVariables' : PSet(),
+    'muonVariables' : PSet(),
+    'tauVariables' : PSet(),
+    'photonVariables' : PSet(),
+    'jetVariables' : PSet(),
+    # dicandidates of form: object1_object2_VarName = 'string expression for candidate'
+    'dicandidateVariables' : PSet(),
+}

--- a/NtupleTools/test/README.rst
+++ b/NtupleTools/test/README.rst
@@ -29,16 +29,15 @@ zero or one) are::
     eventView=0             - make a row in the ntuple correspond to an event
                               instead of a final state in an event.
     passThru=0              - turn off any preselection/skim
-    rerunFSA=1              - regenerate PATFinalState dataformats
     verbose=0               - print out timing information
     noPhotons=0             - don't build things which depend on photons.
     isMC=0                  - run over monte carlo
-    useMiniAOD=1            - run over miniAOD samples rather than UW pattuples
     runDQM=0                - run on single objects instead of final states, plotting many quantities to make sure things work
     use25ns=1               - (with useMiniAOD=1) use conditions for 25ns PHYS14 miniAOD samples
     hzz=0                   - (with useMiniAOD=1) run the H->ZZ->4l group's FSR algorithm, don't clean
                               alternate Z pairings out of ntuples, several other small changes
     nExtraJets=0            - (for non-jet final states) add basic info about this many jets in addition to final state branches
+    paramFile=''            - custom parameter file for ntuple production
 
 Batch submission
 ----------------

--- a/PatTools/python/finalStates/patFinalStateEventProducer_cfi.py
+++ b/PatTools/python/finalStates/patFinalStateEventProducer_cfi.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 patFinalStateEventProducer = cms.EDProducer(
     "PATFinalStateEventProducer",
-    miniAOD = cms.bool(False),
     rhoSrc = cms.InputTag('kt6PFJets', "rho"), #cms.InputTag("kt6PFJetsForRhoComputationVoronoi", "rho"),
     pvSrc = cms.InputTag("selectedPrimaryVertex"),
     pvSrcBackup = cms.InputTag("selectedPrimaryVertexUnclean"),


### PR DESCRIPTION
First off:

@nwoods You beat me! Bah. Mine is much simpler so I vote we look at merging mine first. Then you make a new PR with your changes rebased on mine.

Second:

What is happening. First off, removing useMiniAOD and rerunFSA since they are unneeded without the PAT model. Next the new parameterized make_ntuples. Nate and I keep finding object selections hidden in later files. This is an attempt to move it to make_ntuples and clearly visible. But, we also don't want dozens of `if thisAnalysis: do this` problem. So I have introduced a new parameterized make_ntuples. Defaults to what is currently in FSA. You can copy the default parameter file found in NtupleTools/python/parameters/default.py and then you can make changes.
