### PR TITLE
Starting point for 74X Run2 MiniAOD development

### DIFF
--- a/DataAlgos/interface/helpers.h
+++ b/DataAlgos/interface/helpers.h
@@ -52,7 +52,7 @@ const reco::GenParticleRef getMotherSmart(const reco::GenParticleRef genPart, in
 /// Helper function to get if the gen particle associated comes from higgs 
 const bool comesFromHiggs(const reco::GenParticleRef genPart);
 
-float jetQGVariables(const reco::CandidatePtr  jetptr, const std::string& myvar, const edm::PtrVector<reco::Vertex> recoVertices);
+float jetQGVariables(const reco::CandidatePtr  jetptr, const std::string& myvar, const std::vector<edm::Ptr<reco::Vertex>>& recoVertices);
 
 }
 

--- a/DataAlgos/src/helpers.cc
+++ b/DataAlgos/src/helpers.cc
@@ -263,7 +263,7 @@ const bool findDecay(const reco::GenParticleRefProd genCollectionRef, int pdgIdM
 }
 
 
-float jetQGVariables(const reco::CandidatePtr  jetptr, const std::string& myvar, const edm::PtrVector<reco::Vertex> recoVertices)
+float jetQGVariables(const reco::CandidatePtr  jetptr, const std::string& myvar, const std::vector<edm::Ptr<reco::Vertex>>& recoVertices)
 {
   //std::map <std::string, float> varMap; 
   const pat::Jet *jet = dynamic_cast<const pat::Jet*> (jetptr.get());
@@ -272,7 +272,7 @@ float jetQGVariables(const reco::CandidatePtr  jetptr, const std::string& myvar,
   Bool_t useQC = true;
   // if(fabs(jet->eta()) > 2.5 && type == "MLP") useQC = false;		//In MLP: no QC in forward region
 
-  edm::PtrVector<reco::Vertex>::const_iterator vtxLead = recoVertices.begin();
+  std::vector<edm::Ptr<reco::Vertex>>::const_iterator vtxLead = recoVertices.begin();
 
   Float_t sum_weight = 0., sum_deta = 0., sum_dphi = 0., sum_deta2 = 0., sum_dphi2 = 0., sum_detadphi = 0., sum_pt = 0.;
   Int_t nChg_QC = 0, nChg_ptCut = 0, nNeutral_ptCut = 0;
@@ -290,8 +290,8 @@ float jetQGVariables(const reco::CandidatePtr  jetptr, const std::string& myvar,
       if(part->pt() > 1.0) nChg_ptCut++;
   	
       //Search for closest vertex to track
-      edm::PtrVector<reco::Vertex>::const_iterator  vtxClose = recoVertices.begin();
-      for( edm::PtrVector<reco::Vertex>::const_iterator  vtx = recoVertices.begin(); vtx != recoVertices.end(); ++vtx){
+      std::vector<edm::Ptr<reco::Vertex>>::const_iterator  vtxClose = recoVertices.begin();
+      for( std::vector<edm::Ptr<reco::Vertex>>::const_iterator  vtx = recoVertices.begin(); vtx != recoVertices.end(); ++vtx){
 	if(fabs(itrk->dz((*vtx)->position())) < fabs(itrk->dz((*vtxClose)->position()))) vtxClose = vtx;
       }
   	

--- a/DataFormats/interface/PATFinalStateEvent.h
+++ b/DataFormats/interface/PATFinalStateEvent.h
@@ -57,7 +57,7 @@ class PATFinalStateEvent {
     PATFinalStateEvent(
         double rho,
         const edm::Ptr<reco::Vertex>& pv,
-        const edm::PtrVector<reco::Vertex>& recoVertices,
+        const std::vector<edm::Ptr<reco::Vertex>>& recoVertices,
         const edm::Ptr<pat::MET>& met,
         const TMatrixD& metCovariance,
         const pat::TriggerEvent triggerEvent,
@@ -88,7 +88,8 @@ class PATFinalStateEvent {
     /// Get PV
     const edm::Ptr<reco::Vertex>& pv() const;
     /// Get all reconstructed vertices
-    const edm::PtrVector<reco::Vertex>& recoVertices() const;
+    const std::vector<edm::Ptr<reco::Vertex>>& recoVertices() const;
+    int numberVertices() const;
     /// Get PU information
     const std::vector<PileupSummaryInfo>& puInfo() const;
     /// Get the Les Houches event information
@@ -121,6 +122,7 @@ class PATFinalStateEvent {
 
     /// Get the event ID
     const edm::EventID& evtId() const;
+    int event() const;
 
     /// The following functions use the "SmartTrigger" functionality.
     /// They can be passed a comma separated list of paths:
@@ -206,7 +208,7 @@ class PATFinalStateEvent {
     pat::PackedTriggerPrescales triggerPrescale_;
     edm::TriggerResults triggerResults_;
     edm::Ptr<reco::Vertex> pv_;
-    edm::PtrVector<reco::Vertex> recoVertices_;
+    std::vector<edm::Ptr<reco::Vertex>> recoVertices_;
     edm::Ptr<pat::MET> met_;
     TMatrixD metCovariance_;
     std::vector<PileupSummaryInfo> puInfo_;

--- a/DataFormats/src/PATFinalState.cc
+++ b/DataFormats/src/PATFinalState.cc
@@ -1112,7 +1112,7 @@ const bool PATFinalState::genVtxPVMatch(const size_t i) const
   float genVtxPVDZ = fabs(event_->pv()->z() - genVZ);
 
   // Loop over all vertices, and if there's one that's better, say so
-  for(edm::PtrVector<reco::Vertex>::const_iterator iVtx = event_->recoVertices().begin();
+  for(std::vector<edm::Ptr<reco::Vertex>>::const_iterator iVtx = event_->recoVertices().begin();
       iVtx != event_->recoVertices().end(); ++iVtx)
     {
       if(fabs((*iVtx)->z() - genVZ) < genVtxPVDZ)

--- a/DataFormats/src/PATFinalStateEvent.cc
+++ b/DataFormats/src/PATFinalStateEvent.cc
@@ -56,7 +56,7 @@ PATFinalStateEvent::PATFinalStateEvent(
 PATFinalStateEvent::PATFinalStateEvent(
     double rho,
     const edm::Ptr<reco::Vertex>& pv,
-    const edm::PtrVector<reco::Vertex>& recoVertices,
+    const std::vector<edm::Ptr<reco::Vertex>>& recoVertices,
     const edm::Ptr<pat::MET>& met,
     const TMatrixD& metCovariance,
     const pat::TriggerEvent triggerEvent,
@@ -116,8 +116,12 @@ PATFinalStateEvent::PATFinalStateEvent(
 
 const edm::Ptr<reco::Vertex>& PATFinalStateEvent::pv() const { return pv_; }
 
-const edm::PtrVector<reco::Vertex>& PATFinalStateEvent::recoVertices() const {
+const std::vector<edm::Ptr<reco::Vertex>>& PATFinalStateEvent::recoVertices() const {
   return recoVertices_;
+}
+
+int PATFinalStateEvent::numberVertices() const {
+  return recoVertices().size();
 }
 
 const std::vector<PileupSummaryInfo>& PATFinalStateEvent::puInfo() const {
@@ -202,6 +206,12 @@ const reco::Candidate::LorentzVector PATFinalStateEvent::met4vector(
 
 const edm::EventID& PATFinalStateEvent::evtId() const {
   return evtID_;
+}
+
+int PATFinalStateEvent::event() const {
+  ULong64_t eventNum = evtId().event();
+  int doub = 0;
+  return doub + eventNum;
 }
 
 // Superseded by the smart trigger

--- a/DataFormats/src/classes.h
+++ b/DataFormats/src/classes.h
@@ -38,8 +38,8 @@ namespace {
 
     std::map<std::string, float> dummyFloatMap;
     std::map<std::string, int> dummyIntMap;
-    std::pair<std::string, float> dummyFloatPair;
-    std::pair<std::string, int> dummyIntPair;
+    //std::pair<std::string, float> dummyFloatPair;
+    //std::pair<std::string, int> dummyIntPair;
     std::map<std::string, edm::Ptr<pat::MET> > dummyMETMap;
 
     // For the VBF variables

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -12,17 +12,17 @@
   <class name="edm::RefProd<pat::JetCollection>"/>
 
   <class name="std::map<std::string, float>"/>
-  <class name="std::pair<std::string, float>"/>
   <class name="std::map<std::string, int>"/>
-  <class name="std::pair<std::string, int>"/>
   <class name ="std::map<std::string,edm::Ptr<pat::MET> >" />
 
-  <class name="VBFVariables" ClassVersion="11">
+  <class name="VBFVariables" ClassVersion="12">
+   <version ClassVersion="12" checksum="1002516445"/>
    <version ClassVersion="11" checksum="2844821699"/>
    <version ClassVersion="10" checksum="2474259455"/>
   </class>
 
-  <class name="PATFinalState" ClassVersion="10">
+  <class name="PATFinalState" ClassVersion="11">
+   <version ClassVersion="11" checksum="2004223533"/>
    <version ClassVersion="10" checksum="2840789346"/>
   </class>
   <class name="std::vector<PATFinalState*>"/>
@@ -38,7 +38,7 @@
   </class>
 
   <class name="PATFinalStateEvent" ClassVersion="16">
-   <version ClassVersion="16" checksum="178010298"/>
+   <version ClassVersion="16" checksum="319173420"/>
    <version ClassVersion="15" checksum="1840019056"/>
    <version ClassVersion="14" checksum="1619979458"/>
    <version ClassVersion="13" checksum="3775954220"/>
@@ -65,7 +65,8 @@
   <class name="edm::RefProd<PATFinalStateLSCollection>"/>
   <class name="edm::Ptr<PATFinalStateLS>"/>
 
-  <class name="PATMultiCandFinalState" ClassVersion="10">
+  <class name="PATMultiCandFinalState" ClassVersion="11">
+   <version ClassVersion="11" checksum="2040738471"/>
    <version ClassVersion="10" checksum="3774322392"/>
   </class>
   <class name="PATMultiCandFinalStateCollection"/>

--- a/NtupleTools/python/templates/event.py
+++ b/NtupleTools/python/templates/event.py
@@ -13,7 +13,8 @@ from FinalStateAnalysis.Utilities.cfgtools import PSet
 
 # Vetos on extra stuff in the event
 num = PSet(
-    evt=cms.vstring('evt.evtId.event', 'I'),  # use int branch
+    #evt=cms.vstring('evt.evtId.event', 'I'),  # use int branch
+    evt=cms.vstring('evt.event', 'I'),  # use int branch
     lumi=cms.vstring('evt.evtId.luminosityBlock', 'I'),  # use int branch
     run=cms.vstring('evt.evtId.run', 'I'),  # use int branch
     isdata=cms.vstring('evt.isRealData', 'I'),
@@ -21,7 +22,8 @@ num = PSet(
 
 pileup = PSet(
     rho='evt.rho',
-    nvtx='evt.recoVertices.size',
+    #nvtx='evt.recoVertices.size',
+    nvtx='evt.numberVertices',
     # Number of true PU events
     nTruePU='? evt.puInfo.size > 0 ? evt.puInfo[1].getTrueNumInteractions :-1',
 )

--- a/NtupleTools/python/templates/muons.py
+++ b/NtupleTools/python/templates/muons.py
@@ -86,7 +86,7 @@ tracking = PSet(
     objectMuonHits = '? {object}.globalTrack.isNonnull ? '
         '{object}.globalTrack().hitPattern().numberOfValidMuonHits() : -1',
     objectMatchedStations = '{object}.numberOfMatchedStations',
-    objectD0 = '{object}.dB("PV3D")',
+    #objectD0 = '{object}.dB("PV3D")',
 )
 
 # Trigger matching

--- a/NtupleTools/test/make_ntuples_cfg.py
+++ b/NtupleTools/test/make_ntuples_cfg.py
@@ -51,9 +51,6 @@ from FinalStateAnalysis.NtupleTools.ntuple_builder import \
     make_ntuple, add_ntuple
 from FinalStateAnalysis.Utilities.version import cmssw_major_version, \
     cmssw_minor_version
-from FinalStateAnalysis.NtupleTools.rerun_matchers import rerun_matchers
-from FinalStateAnalysis.NtupleTools.rerun_QGJetID import rerun_QGJetID
-from FinalStateAnalysis.NtupleTools.rerun_Jets import rerun_jets
 import PhysicsTools.PatAlgos.tools.helpers as helpers
 
 process = cms.Process("Ntuples")

--- a/PatTools/interface/PhosphorCorrectorFunctor.hh
+++ b/PatTools/interface/PhosphorCorrectorFunctor.hh
@@ -81,7 +81,7 @@ namespace zgamma{
     map < string, double > CorrMap;
     map < string, double > ErrMap;
     map < int, int > CatMap;
-    ifstream MapFile;
+    std::ifstream MapFile;
     const char* filename;
 
     //Private Methods

--- a/PatTools/plugins/MiniAODJetInfoEmbedder.cc
+++ b/PatTools/plugins/MiniAODJetInfoEmbedder.cc
@@ -20,7 +20,8 @@
 namespace {
   // Taus we can get the value straight from the jet
   reco::Candidate::LorentzVector extractObjectP4(const pat::Tau& tau) {
-    return tau.pfEssential().p4Jet_;
+    //return tau.pfEssential().p4Jet_;
+    return tau.p4();
   }
 
   reco::Candidate::LorentzVector extractObjectP4(const pat::Muon& mu) {

--- a/PatTools/plugins/PATElectronSystematicsEmbedder.cc
+++ b/PatTools/plugins/PATElectronSystematicsEmbedder.cc
@@ -61,7 +61,7 @@ void PATElectronSystematicsEmbedder::produce(edm::Event& evt, const edm::EventSe
     pat::Electron electron = electrons->at(i); // make a local copy
 
     double pt = electron.pt();
-    ShiftedCand uncorr(electron);
+    ShiftedCand uncorr = *electron.clone();
 
     double correctedPt = nominal_*pt;
     double correctedPtUp = eScaleUp_*pt;
@@ -74,8 +74,8 @@ void PATElectronSystematicsEmbedder::produce(edm::Event& evt, const edm::EventSe
     electron.setP4(reco::Particle::PolarLorentzVector(
           correctedPt, eta, phi, mass));
 
-    ShiftedCand mesUp(electron);
-    ShiftedCand mesDown(electron);
+    ShiftedCand mesUp = *electron.clone();
+    ShiftedCand mesDown = *electron.clone();
 
     mesUp.setP4(reco::Particle::PolarLorentzVector(
           correctedPtUp, eta, phi, mass));

--- a/PatTools/plugins/PATFinalStateEventProducer.cc
+++ b/PatTools/plugins/PATFinalStateEventProducer.cc
@@ -198,7 +198,7 @@ void PATFinalStateEventProducer::produce(edm::Event& evt,
               << " pvPtr is not set !!!!!" << std::endl;
   edm::Handle<edm::View<reco::Vertex> > vertices;
   evt.getByToken(verticesSrc_, vertices);
-  edm::PtrVector<reco::Vertex> verticesPtr = vertices->ptrVector();
+  std::vector<edm::Ptr<reco::Vertex>> verticesPtr = vertices->ptrs();
 
   // Get refs to the objects in the event
   edm::RefProd<pat::ElectronCollection> electronRefProd =

--- a/PatTools/plugins/PATJetSmearEmbedder.cc
+++ b/PatTools/plugins/PATJetSmearEmbedder.cc
@@ -147,9 +147,9 @@ class PATJetSmearEmbedder : public edm::EDProducer
       reco::Candidate::LorentzVector smearUpP4 = jetP4;
       reco::Candidate::LorentzVector smearDownP4 = jetP4;
 
-      ShiftedCand smearedCand(outputJet);
-      ShiftedCand smearUpCand(outputJet);
-      ShiftedCand smearDownCand(outputJet);
+      ShiftedCand smearedCand = *outputJet.clone();
+      ShiftedCand smearUpCand = *outputJet.clone();
+      ShiftedCand smearDownCand = *outputJet.clone();
 
       // Only smear MC
       if (!evt.isRealData()) {

--- a/PatTools/plugins/PATJetSystematicsEmbedder.cc
+++ b/PatTools/plugins/PATJetSystematicsEmbedder.cc
@@ -82,14 +82,14 @@ void PATJetSystematicsEmbedder::produce(edm::Event& evt, const edm::EventSetup& 
     LorentzVector uncUESDown = (1-unclusteredEnergyScale_)*jet.p4();
     LorentzVector uncUESUp = (1+unclusteredEnergyScale_)*jet.p4();
 
-    ShiftedCand candUncDown(jet);
+    ShiftedCand candUncDown = *jet.clone();
     candUncDown.setP4(uncDown);
-    ShiftedCand candUncUp(jet);
+    ShiftedCand candUncUp = *jet.clone();
     candUncUp.setP4(uncUp);
 
-    ShiftedCand candUncUESDown(jet);
+    ShiftedCand candUncUESDown = *jet.clone();
     candUncUESDown.setP4(uncUESDown);
-    ShiftedCand candUncUESUp(jet);
+    ShiftedCand candUncUESUp = *jet.clone();
     candUncUESUp.setP4(uncUESUp);
 
     p4OutJESUpJets->push_back(candUncUp);

--- a/PatTools/plugins/PATJetUncorrectedEmbedder.cc
+++ b/PatTools/plugins/PATJetUncorrectedEmbedder.cc
@@ -50,7 +50,7 @@ void PATJetUncorrectedEmbedder::produce(edm::Event& evt, const edm::EventSetup& 
   for (size_t i = 0; i < nJets; ++i) {
     const pat::Jet& jet = jets->at(i);
     output->push_back(jet); // make our own copy
-    ShiftedCand uncorr(jet);
+    ShiftedCand uncorr = *jet.clone();
     LorentzVector uncorrectedP4 = jet.correctedP4("Uncorrected");
     uncorr.setP4(uncorrectedP4);
     uncorrected->push_back(uncorr);

--- a/PatTools/plugins/PATMETSystematicsEmbedder.cc
+++ b/PatTools/plugins/PATMETSystematicsEmbedder.cc
@@ -91,7 +91,7 @@ void embedShift(pat::MET& met, edm::Event& evt,
   typedef reco::CandidatePtr CandidatePtr;
 
   std::auto_ptr<ShiftedCandCollection> output(new ShiftedCandCollection);
-  ShiftedCand newCand(met);
+  ShiftedCand newCand = *met.clone();
   newCand.setP4(transverse(newCand.p4() + residual));
   output->push_back(newCand);
   PutHandle outputH = evt.put(output, branchName);

--- a/PatTools/plugins/PATMuonSystematicsEmbedder.cc
+++ b/PatTools/plugins/PATMuonSystematicsEmbedder.cc
@@ -111,10 +111,10 @@ void PATMuonSystematicsEmbedder::produce(edm::Event& evt, const edm::EventSetup&
     double phi = muon.phi();
     double mass = muon.mass();
 
-    ShiftedCand uncorr(muon);
-    ShiftedCand nominal(muon);
-    ShiftedCand mesUp(muon);
-    ShiftedCand mesDown(muon);
+    ShiftedCand uncorr = *muon.clone();
+    ShiftedCand nominal = *muon.clone();
+    ShiftedCand mesUp = *muon.clone();
+    ShiftedCand mesDown = *muon.clone();
 
     // Don't apply the correction by default, no one else does.
 

--- a/PatTools/plugins/PATTauGenInfoEmbedder.cc
+++ b/PatTools/plugins/PATTauGenInfoEmbedder.cc
@@ -40,9 +40,8 @@ void PATTauGenInfoEmbedder::produce(edm::Event& evt, const edm::EventSetup& es) 
   output->reserve(taus->size());
 
   // Loop over input taus
-  edm::PtrVector<pat::Tau> ptrs = taus->ptrVector();
-  for (size_t i = 0; i < ptrs.size(); ++i) {
-    pat::Tau copy = *ptrs[i];
+  for (size_t i = 0; i < taus->size(); ++i) {
+    pat::Tau copy = *taus->ptrAt(i);
     int decayModeIndex = -2;
     if (copy.genJet() != NULL) {
       decayModeIndex = reco::tau::getDecayMode(copy.genJet());

--- a/PatTools/plugins/PATTauSystematicsEmbedder.cc
+++ b/PatTools/plugins/PATTauSystematicsEmbedder.cc
@@ -172,17 +172,17 @@ void PATTauSystematicsEmbedder::produce(edm::Event& evt, const edm::EventSetup& 
   for (size_t i = 0; i < nTaus; ++i) {
     const pat::Tau& origTau = taus->at(i);
     output->push_back(origTau); // make our own copy
-    ShiftedCand p4OutNomTau(origTau);
+    ShiftedCand p4OutNomTau = *origTau.clone();
     p4OutNomTaus->push_back(p4OutNomTau);
     // Now make the smeared versions of the jets and taus
     // TES uncertainty
     ShiftedLorentzVectors tesShifts = tauJetCorrection_.uncertainties(
         p4OutNomTau.p4());
-    ShiftedCand p4OutTESUpTau(p4OutNomTau);
+    ShiftedCand p4OutTESUpTau = *p4OutNomTau.clone();
     p4OutTESUpTau.setP4(tesShifts.shiftedUp);
     p4OutTESUpTaus->push_back(p4OutTESUpTau);
 
-    ShiftedCand p4OutTESDownTau(p4OutNomTau);
+    ShiftedCand p4OutTESDownTau = *p4OutNomTau.clone();
     p4OutTESDownTau.setP4(tesShifts.shiftedDown);
     p4OutTESDownTaus->push_back(p4OutTESDownTau);
   }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ PAT tuple, and utilities for generating plain ROOT ntuples from the PAT tuple.
 Installation
 ------------
 
-Current CMSSW version: ``7_2_X``.
+Current CMSSW version: ``7_4_1``.
 
 Get a supported CMSSW release area:
 
@@ -30,7 +30,7 @@ Get a supported CMSSW release area:
 Checkout the FinalStateAnalysis repository:
 
 ```bash
-  git clone --recursive -b miniAOD_dev git@github.com:uwcms/FinalStateAnalysis.git
+  git clone --recursive -b miniAOD_dev_74X git@github.com:uwcms/FinalStateAnalysis.git
   cd FinalStateAnalysis
 ```
 

--- a/RecoTools/plugins/CandViewOverlapSubtraction.cc
+++ b/RecoTools/plugins/CandViewOverlapSubtraction.cc
@@ -51,14 +51,11 @@ bool CandViewOverlapSubtraction::filter(edm::Event& evt, const edm::EventSetup& 
   std::auto_ptr<reco::CandidateBaseRefVector> output(
       new reco::CandidateBaseRefVector());
 
-  const reco::CandidateBaseRefVector &toFilter = candsToFilter->refVector();
-  const reco::CandidateBaseRefVector &toSubtract = candsToSubtract->refVector();
-
-  for (size_t i = 0; i < toFilter.size(); ++i) {
-    const reco::CandidateBaseRef& baseRef = toFilter[i];
+  for (size_t i = 0; i < candsToFilter->size(); ++i) {
+    const reco::CandidateBaseRef& baseRef = candsToFilter->refAt(i);
     bool passes = true;
-    for (size_t j = 0; j < toSubtract.size(); ++j) {
-      double deltaR = reco::deltaR(baseRef->p4(), toSubtract[j]->p4());
+    for (size_t j = 0; j < candsToSubtract->size(); ++j) {
+      double deltaR = reco::deltaR(baseRef->p4(), candsToSubtract->refAt(j)->p4());
       if (deltaR < minDeltaR_) {
         passes = false;
         break;
@@ -68,6 +65,7 @@ bool CandViewOverlapSubtraction::filter(edm::Event& evt, const edm::EventSetup& 
       output->push_back(baseRef);
     }
   }
+
   size_t outputSize = output->size();
   evt.put(output);
   return ( !filter_ || outputSize );

--- a/RecoTools/plugins/PFJetViewOverlapSubtraction.cc
+++ b/RecoTools/plugins/PFJetViewOverlapSubtraction.cc
@@ -57,14 +57,11 @@ bool PFJetViewOverlapSubtraction::filter(edm::Event& evt, const edm::EventSetup&
   std::auto_ptr<reco::PFJetCollection> output(
       new reco::PFJetCollection());
 
-  const edm::PtrVector<reco::PFJet> &toFilter = candsToFilter->ptrVector();
-  const reco::CandidateBaseRefVector &toSubtract = candsToSubtract->refVector();
-
-  for (size_t i = 0; i < toFilter.size(); ++i) {
-    edm::Ptr<reco::PFJet> baseRef = toFilter[i];
+  for (size_t i = 0; i < candsToFilter->size(); ++i) {
+    edm::RefToBase<reco::PFJet> baseRef = candsToFilter->refAt(i);
     bool passes = true;
-    for (size_t j = 0; j < toSubtract.size(); ++j) {
-      double deltaR = reco::deltaR(baseRef->p4(), toSubtract[j]->p4());
+    for (size_t j = 0; j < candsToSubtract->size(); ++j) {
+      double deltaR = reco::deltaR(baseRef->p4(), candsToSubtract->refAt(j)->p4());
       if (deltaR < minDeltaR_) {
         passes = false;
         break;
@@ -76,6 +73,7 @@ bool PFJetViewOverlapSubtraction::filter(edm::Event& evt, const edm::EventSetup&
       output->push_back(*baseRef);
     }
   }
+
   size_t outputSize = output->size();
   evt.put(output);
   return ( !filter_ || outputSize );

--- a/Utilities/interface/ExpressionNtuple.h
+++ b/Utilities/interface/ExpressionNtuple.h
@@ -11,10 +11,10 @@
 #include "boost/utility.hpp"
  #include <boost/ptr_container/ptr_vector.hpp>
 
-#include "Reflex/Type.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CommonTools/Utils/interface/TFileDirectory.h"
 #include "TTree.h"
+#include "FWCore/Utilities/interface/TypeWithDict.h"
 
 #include "FinalStateAnalysis/Utilities/interface/ExpressionNtupleColumn.h"
 
@@ -139,9 +139,9 @@ template<class T>
 void ExpressionNtuple<std::vector<const T*> >::initialize(TFileDirectory& fs) {
   tree_ = fs.make<TTree>("Ntuple", "Expression Ntuple");
   // build the index branch
-  Reflex::Type theType = Reflex::Type::ByTypeInfo(typeid(T));
   std::stringstream name, leaf;
-  name << "N_"  << theType.Name();
+  edm::TypeWithDict t(typeid(T));
+  name << "N_"  << t.name();
   leaf << name.str() << "/I";
   
   // In this specialization the idx is allows us to have

--- a/Utilities/interface/ExpressionNtupleColumn.h
+++ b/Utilities/interface/ExpressionNtupleColumn.h
@@ -19,13 +19,13 @@
 #ifndef EXPRESSIONNTUPLECOLUMN_VOU3DWMC
 #define EXPRESSIONNTUPLECOLUMN_VOU3DWMC
 
-#include "Reflex/Type.h"
 #include <TTree.h>
 #include <TLeaf.h>
 #include "CommonTools/Utils/interface/StringObjectFunction.h"
 #include <TMath.h>
 #include <iostream>
 #include <sstream>
+#include "FWCore/Utilities/interface/TypeWithDict.h"
 
 template<typename ObjType>
 class ExpressionNtupleColumn {
@@ -267,8 +267,8 @@ ExpressionNtupleColumnT(const std::string& name,
   branch_.reset(new ColType[1]);
 
   std::stringstream idxwrap;
-  Reflex::Type theType = Reflex::Type::ByTypeInfo(typeid(T));
-  idxwrap << "[N_" << theType.Name() << "]";
+  edm::TypeWithDict t(typeid(T));
+  idxwrap << "[N_" << t.name() << "]";
 
   std::string branchCmd = name + idxwrap.str() + getTypeCmd<ColType>();
   std::string fullName = name;

--- a/recipe/recipe_13TeV.sh
+++ b/recipe/recipe_13TeV.sh
@@ -13,42 +13,55 @@ MINOR_VERSION=`echo $CMSSW_VERSION | sed "s|CMSSW_\([0-9]\)_\([0-9]\)_.*|\2|"`
 
 pushd $CMSSW_BASE/src
 
-echo "Need to update recipe for Quark Gluon Jet ID - which is the correct tag?"
-#echo "Downloading Quark Gluon Jet ID"
-# Quark-gluon tagging
-git clone https://github.com/amarini/QuarkGluonTagger.git
-pushd $CMSSW_BASE/src/QuarkGluonTagger
-git checkout v1-2-6
-popd
+
+# Hack for 74X until recipes available
+git cms-addpkg EgammaAnalysis/ElectronTools
+mv EgammaAnalysis/ElectronTools/interface/EGammaCutBasedEleId.h EgammaAnalysis/ElectronTools/interface/EGammaCutBasedEleId.h.orig
+cp /cms/dntaylor/FSA_PHYS14/CMSSW_7_2_4/src/EgammaAnalysis/ElectronTools/interface/EGammaCutBasedEleId.h EgammaAnalysis/ElectronTools/interface/
+cp /cms/dntaylor/FSA_PHYS14/CMSSW_7_2_4/src/EgammaAnalysis/ElectronTools/interface/EGammaMvaEleEstimatorCSA14.h EgammaAnalysis/ElectronTools/interface/
+cp /cms/dntaylor/FSA_PHYS14/CMSSW_7_2_4/src/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimatorCSA14.cc EgammaAnalysis/ElectronTools/src/
+cp -r /cms/dntaylor/FSA_PHYS14/CMSSW_7_2_4/src/EgammaAnalysis/ElectronTools/data/PHYS14/ EgammaAnalysis/ElectronTools/data/
+cp -r /cms/dntaylor/FSA_PHYS14/CMSSW_7_2_4/src/EgammaAnalysis/ElectronTools/data/CSA14/ EgammaAnalysis/ElectronTools/data/
+git cms-addpkg RecoEgamma/ElectronIdentification
+cp -r /cms/dntaylor/FSA_PHYS14/CMSSW_7_2_4/src/RecoEgamma/ElectronIdentification/python/Identification/ RecoEgamma/ElectronIdentification/python/
+cp /afs/cern.ch/user/i/ikrav/public/EGMCode/GsfEleFull5x5SigmaIEtaIEtaCut72X.cc RecoEgamma/ElectronIdentification/plugins/cuts/
+
+#echo "Need to update recipe for Quark Gluon Jet ID - which is the correct tag?"
+##echo "Downloading Quark Gluon Jet ID"
+## Quark-gluon tagging
+#git clone https://github.com/amarini/QuarkGluonTagger.git
+#pushd $CMSSW_BASE/src/QuarkGluonTagger
+#git checkout v1-2-6
+#popd
 
 
 # These recipes are sort of "hacky" at the moment, pending updates to the official EGM ID framework
 # From https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2#Working_points_for_PHYS14_sample (cut based)
 # and  https://twiki.cern.ch/twiki/bin/viewauth/CMS/MultivariateElectronIdentificationRun2 (MVA)
-echo "Checking out electron IDs for miniAOD in CMSSW_7_2_X"
-git cms-merge-topic HuguesBrun:trigElecIdInCommonIsoSelection720
-cp /afs/cern.ch/user/i/ikrav/public/EGMCode/GsfEleFull5x5SigmaIEtaIEtaCut72X.cc RecoEgamma/ElectronIdentification/plugins/cuts/
-cp /afs/cern.ch/user/i/ikrav/public/EGMCode/cutBasedElectronID_PHYS14_PU20bx25_V0_miniAOD_cff.py RecoEgamma/ElectronIdentification/python/Identification/
-cp /afs/cern.ch/user/i/ikrav/public/EGMCode/cutBasedElectronID_PHYS14_PU20bx25_V1_miniAOD_cff.py RecoEgamma/ElectronIdentification/python/Identification/
+#echo "Checking out electron IDs for miniAOD in CMSSW_7_2_X"
+#git cms-merge-topic HuguesBrun:trigElecIdInCommonIsoSelection720
+#cp /afs/cern.ch/user/i/ikrav/public/EGMCode/GsfEleFull5x5SigmaIEtaIEtaCut72X.cc RecoEgamma/ElectronIdentification/plugins/cuts/
+#cp /afs/cern.ch/user/i/ikrav/public/EGMCode/cutBasedElectronID_PHYS14_PU20bx25_V0_miniAOD_cff.py RecoEgamma/ElectronIdentification/python/Identification/
+#cp /afs/cern.ch/user/i/ikrav/public/EGMCode/cutBasedElectronID_PHYS14_PU20bx25_V1_miniAOD_cff.py RecoEgamma/ElectronIdentification/python/Identification/
 
-echo "Checking out EGamma POG recipe for electron corrections"
-git cms-addpkg EgammaAnalysis/ElectronTools
+#echo "Checking out EGamma POG recipe for electron corrections"
+#git cms-addpkg EgammaAnalysis/ElectronTools
 
-set +o errexit
-patch -N -p0 < FinalStateAnalysis/recipe/patches/Egamma_PassAll.patch
-set -o errexit
+#set +o errexit
+#patch -N -p0 < FinalStateAnalysis/recipe/patches/Egamma_PassAll.patch
+#set -o errexit
 
 #Get weight files
-pushd $CMSSW_BASE/src/EgammaAnalysis/ElectronTools/data
-cat download.url | xargs wget
-popd
+#pushd $CMSSW_BASE/src/EgammaAnalysis/ElectronTools/data
+#cat download.url | xargs wget
+#popd
 
-echo "Checking out recipe for mvamet"
-# https://twiki.cern.ch/twiki/bin/viewauth/CMS/MVAMet#CMSSW_7_2_X_requires_slc6_MiniAO
-git-cms-merge-topic -u cms-met:72X-13TeV-Training-30Jan15
-pushd $CMSSW_BASE/src/RecoMET/METPUSubtraction
-git clone https://github.com/rfriese/RecoMET-METPUSubtraction data -b 72X-13TeV-Phys14_25_V4-26Mar15
-popd
+#echo "Checking out recipe for mvamet"
+## https://twiki.cern.ch/twiki/bin/viewauth/CMS/MVAMet#CMSSW_7_2_X_requires_slc6_MiniAO
+#git-cms-merge-topic -u cms-met:72X-13TeV-Training-30Jan15
+#pushd $CMSSW_BASE/src/RecoMET/METPUSubtraction
+#git clone https://github.com/rfriese/RecoMET-METPUSubtraction data -b 72X-13TeV-Phys14_25_V4-26Mar15
+#popd
 
 # HZZ MELA, MEKD etc.
 if [ "$HZZ" = "1" ]; then

--- a/recipe/recipe_common.sh
+++ b/recipe/recipe_common.sh
@@ -16,10 +16,10 @@ popd
 
 # Add and patch to way speed up trigger matching
 # Don't crash if patch already applied.
-set +o errexit
-echo "Applying pat trigger matching speedup"
-git cms-addpkg DataFormats/PatCandidates
-git apply FinalStateAnalysis/recipe/patches/DataFormats_PatCandidates_TriggerEvent.cc.patch
-set -o errexit
+#set +o errexit
+#echo "Applying pat trigger matching speedup"
+#git cms-addpkg DataFormats/PatCandidates
+#git apply FinalStateAnalysis/recipe/patches/DataFormats_PatCandidates_TriggerEvent.cc.patch
+#set -o errexit
 
 popd


### PR DESCRIPTION
Super hacky at the moment.

Important things to note:
- ElectronID is pretty forced at the moment, I'm just copying over select pieces of code until it compiles. Can't do a merge-topic with CMSSW 72X branch because more fundamental things break. Once a recipe is released, switch this! PHYS14 IDs are in though.
- SVFit compiles, have not tested because mvamet looks complicated to implement at the moment without a 74X recipe. So I will wait.
- EventID::event() method now returns a ULong64_t. I hacked it so that it gets converted to an int using PATFinalStateEvent. However, it would be best to probably implement this appropriately in ExpressionNtupleColumn (I think the type label is `l`). Shouldn't become a problem unless we somehow get 2^31 events in a single run.
- edm::PtrVector is becoming unsupported. This presents an issue with the reco::Vertex list. Made it so it gets the number of vertices in PATFinalStateEvent rather than getting the size of the recoVertices directly. This should be looked at.
- ROOT6!!! No more reflex. I've switched away from it where things break. But there is probably a way to remove other things too and I need to read up on it to clean out.

How I tested this:

I am using an output from a personal MINIAODSIM production. The recipe is being finalized for 74X now that the jet calibration has been fixed. I'll have a tutorial posted in our group meeting this evening [http://agenda.hep.wisc.edu/conferenceDisplay.py?confId=887](http://agenda.hep.wisc.edu/conferenceDisplay.py?confId=887).

To test out of the box:

```
cmsRun make_ntuples_cfg.py channels="dqm" isMC=1 inputFiles=file:/hdfs/store/user/dntaylor/2015-04-27_HppHmmTo4L_M-500_13TeV-pythia8_step3_v1-RunIISpring15DR74_25ns_3_cfg/RunIISpring15DR74_25ns_3_cfg-RunIISpring15DR74_25ns_2_cfg-RunIISpring15DR74_25ns_1_cfg-RunIIWinter15GS_117.root maxEvents=1000
```
