### PR TITLE
Fix gen matching bug and add a pre-fsr gen matching option

### DIFF
--- a/DataAlgos/interface/helpers.h
+++ b/DataAlgos/interface/helpers.h
@@ -23,36 +23,42 @@
 
 namespace fshelpers {
 
-/// Compute the significance of a vector given the covariance
-double xySignficance(const reco::Candidate::Vector& vector,
-    const TMatrixD& covariance);
+  /// Compute the significance of a vector given the covariance
+  double xySignficance(const reco::Candidate::Vector& vector,
+                       const TMatrixD& covariance);
 
-// By C. Veelken - returns pZeta, pZetaVis
-std::pair<double, double> pZeta(const reco::Candidate::LorentzVector& leg1,
-    const reco::Candidate::LorentzVector& leg2, double metPx, double metPy);
+  // By C. Veelken - returns pZeta, pZetaVis
+  std::pair<double, double> pZeta(const reco::Candidate::LorentzVector& leg1,
+                                  const reco::Candidate::LorentzVector& leg2, double metPx, double metPy);
 
-double transverseMass(const reco::Candidate::LorentzVector& p1,
-    const reco::Candidate::LorentzVector& p2);
+  double transverseMass(const reco::Candidate::LorentzVector& p1,
+                        const reco::Candidate::LorentzVector& p2);
 
-const reco::Candidate::LorentzVector metPhiCorrection(const reco::Candidate::LorentzVector& vector, int nvertices, bool isMC);
+  const reco::Candidate::LorentzVector metPhiCorrection(const reco::Candidate::LorentzVector& vector, int nvertices, bool isMC);
 
-// Taken from CommonTools/CandUtils/AddFourMomenta.h
-// makes sure the composite objects P4 = sum of daughters
-void addFourMomenta(reco::Candidate & c);
+  // Taken from CommonTools/CandUtils/AddFourMomenta.h
+  // makes sure the composite objects P4 = sum of daughters
+  void addFourMomenta(reco::Candidate & c);
 
-/// Helper function to get the matched gen particle 
-const reco::GenParticleRef getGenParticle(const reco::Candidate*   daughter,const reco::GenParticleRefProd genCollectionRef, int pdgIdToMatch, bool checkCharge);
+  /// Helper function to get the matched status 1 gen particle.
+  /// If preFSR is true, the last unbranched particle in the matched
+  /// particle's chain is returned instead. This is not guaranteed to
+  /// work for any generators except Pythia6 and Pythia8.
+  const reco::GenParticleRef getGenParticle(const reco::Candidate* daughter,
+                                            const reco::GenParticleRefProd genCollectionRef, 
+                                            int pdgIdToMatch, bool checkCharge, 
+                                            bool preFSR=false);
 
-///Helper function to find a gen particle given pdgid and status
-const bool findDecay(const reco::GenParticleRefProd genCollectionRef, int pdgIdMother, int pdgIdDaughter);
+  ///Helper function to find a gen particle given pdgid and status
+  const bool findDecay(const reco::GenParticleRefProd genCollectionRef, int pdgIdMother, int pdgIdDaughter);
 
-/// Helper function to get the first interesting mother particle 
-const reco::GenParticleRef getMotherSmart(const reco::GenParticleRef genPart, int idNOTtoMatch = -999);
+  /// Helper function to get the first interesting mother particle 
+  const reco::GenParticleRef getMotherSmart(const reco::GenParticleRef genPart, int idNOTtoMatch = -999);
 
-/// Helper function to get if the gen particle associated comes from higgs 
-const bool comesFromHiggs(const reco::GenParticleRef genPart);
+  /// Helper function to get if the gen particle associated comes from higgs 
+  const bool comesFromHiggs(const reco::GenParticleRef genPart);
 
-float jetQGVariables(const reco::CandidatePtr  jetptr, const std::string& myvar, const edm::PtrVector<reco::Vertex> recoVertices);
+  float jetQGVariables(const reco::CandidatePtr  jetptr, const std::string& myvar, const edm::PtrVector<reco::Vertex> recoVertices);
 
 }
 

--- a/DataAlgos/src/helpers.cc
+++ b/DataAlgos/src/helpers.cc
@@ -22,341 +22,412 @@
 
 namespace fshelpers {
 
-double xySignficance(const reco::Candidate::Vector& vector,
-    const TMatrixD& covariance) {
-  // Instead of playing around w/ vector types to get ROOT
-  // to do this for us, just do it manually.
-  double vx = vector.x();
-  double vy = vector.y();
-  double mag2 = vx*vx + vy*vy;
-  double mag = TMath::Sqrt(mag2);
+  double xySignficance(const reco::Candidate::Vector& vector,
+                       const TMatrixD& covariance) {
+    // Instead of playing around w/ vector types to get ROOT
+    // to do this for us, just do it manually.
+    double vx = vector.x();
+    double vy = vector.y();
+    double mag2 = vx*vx + vy*vy;
+    double mag = TMath::Sqrt(mag2);
 
-  if (mag < 1.0e-9)
-    return -1;
+    if (mag < 1.0e-9)
+      return -1;
 
-  // vT dot cov dot v
-  double c00 = covariance(0,0);
-  double c01 = covariance(0,1);
-  double c10 = covariance(1,0);
-  double c11 = covariance(1,1);
+    // vT dot cov dot v
+    double c00 = covariance(0,0);
+    double c01 = covariance(0,1);
+    double c10 = covariance(1,0);
+    double c11 = covariance(1,1);
 
-  double covDotVx = (c00*vx + c01*vy);
-  double covDotVy = (c10*vx + c11*vy);
+    double covDotVx = (c00*vx + c01*vy);
+    double covDotVy = (c10*vx + c11*vy);
 
-  double vTdotCovDotV = vx*covDotVx + vy*covDotVy;
+    double vTdotCovDotV = vx*covDotVx + vy*covDotVy;
 
-  if (vTdotCovDotV < 0)
-    return -2;
+    if (vTdotCovDotV < 0)
+      return -2;
 
-  // compute error pointing along the vector
-  double error = TMath::Sqrt(vTdotCovDotV)/mag;
+    // compute error pointing along the vector
+    double error = TMath::Sqrt(vTdotCovDotV)/mag;
 
-  return mag/error;
-}
-
-// By C. Veelken
-std::pair<double, double> pZeta( const reco::Candidate::LorentzVector& leg1,
-    const reco::Candidate::LorentzVector& leg2, double metPx, double metPy) {
-  //std::cout << "<CompositePtrCandidateT1T2MEtAlgorithm::compZeta>:" << std::endl;
-
-  double leg1x = cos(leg1.phi());
-  double leg1y = sin(leg1.phi());
-  double leg2x = cos(leg2.phi());
-  double leg2y = sin(leg2.phi());
-  double zetaX = leg1x + leg2x;
-  double zetaY = leg1y + leg2y;
-  double zetaR = TMath::Sqrt(zetaX*zetaX + zetaY*zetaY);
-  if ( zetaR > 0. ) {
-    zetaX /= zetaR;
-    zetaY /= zetaR;
+    return mag/error;
   }
 
-  //std::cout << " leg1Phi = " << leg1.phi()*180./TMath::Pi() << std::endl;
-  //std::cout << " leg2Phi = " << leg2.phi()*180./TMath::Pi() << std::endl;
+  // By C. Veelken
+  std::pair<double, double> pZeta( const reco::Candidate::LorentzVector& leg1,
+                                   const reco::Candidate::LorentzVector& leg2, double metPx, double metPy) {
+    //std::cout << "<CompositePtrCandidateT1T2MEtAlgorithm::compZeta>:" << std::endl;
 
-  //std::cout << " zetaX = " << zetaX << std::endl;
-  //std::cout << " zetaY = " << zetaY << std::endl;
+    double leg1x = cos(leg1.phi());
+    double leg1y = sin(leg1.phi());
+    double leg2x = cos(leg2.phi());
+    double leg2y = sin(leg2.phi());
+    double zetaX = leg1x + leg2x;
+    double zetaY = leg1y + leg2y;
+    double zetaR = TMath::Sqrt(zetaX*zetaX + zetaY*zetaY);
+    if ( zetaR > 0. ) {
+      zetaX /= zetaR;
+      zetaY /= zetaR;
+    }
 
-  //std::cout << " zetaPhi = " << normalizedPhi(atan2(zetaY, zetaX))*180./TMath::Pi() << std::endl;
+    //std::cout << " leg1Phi = " << leg1.phi()*180./TMath::Pi() << std::endl;
+    //std::cout << " leg2Phi = " << leg2.phi()*180./TMath::Pi() << std::endl;
 
-  double visPx = leg1.px() + leg2.px();
-  double visPy = leg1.py() + leg2.py();
-  double pZetaVis = visPx*zetaX + visPy*zetaY;
+    //std::cout << " zetaX = " << zetaX << std::endl;
+    //std::cout << " zetaY = " << zetaY << std::endl;
 
-  //std::cout << " visPx = " << visPx << std::endl;
-  //std::cout << " visPy = " << visPy << std::endl;
+    //std::cout << " zetaPhi = " << normalizedPhi(atan2(zetaY, zetaX))*180./TMath::Pi() << std::endl;
 
-  double px = visPx + metPx;
-  double py = visPy + metPy;
-  double pZeta = px*zetaX + py*zetaY;
+    double visPx = leg1.px() + leg2.px();
+    double visPy = leg1.py() + leg2.py();
+    double pZetaVis = visPx*zetaX + visPy*zetaY;
 
-  //std::cout << " metPhi = " << normalizedPhi(atan2(metPy, metPx))*180./TMath::Pi() << std::endl;
+    //std::cout << " visPx = " << visPx << std::endl;
+    //std::cout << " visPy = " << visPy << std::endl;
 
-  //assert(pZetaVis >= 0.);
+    double px = visPx + metPx;
+    double py = visPy + metPy;
+    double pZeta = px*zetaX + py*zetaY;
 
-  return std::make_pair(pZeta, pZetaVis);
-}
+    //std::cout << " metPhi = " << normalizedPhi(atan2(metPy, metPx))*180./TMath::Pi() << std::endl;
 
-double transverseMass(const reco::Candidate::LorentzVector& p1,
-    const reco::Candidate::LorentzVector& p2){
-  double totalEt = p1.Et() + p2.Et();
-  double totalPt = (p1 + p2).pt();
-  double mt2 = totalEt*totalEt - totalPt*totalPt;
-  if (mt2 < 0) {
-    std::cout << "P1 = " << p1 << " P2 = " << p2 << " " << mt2 << std::endl;
+    //assert(pZetaVis >= 0.);
+
+    return std::make_pair(pZeta, pZetaVis);
   }
-  return std::sqrt(std::abs(mt2));
-}
 
-// Taken from CommonTools/CandUtils/AddFourMomenta.h
-void addFourMomenta( reco::Candidate & c ) {
-  reco::Candidate::LorentzVector p4( 0, 0, 0, 0 );
-  reco::Candidate::Charge charge = 0;
-  size_t n = c.numberOfDaughters();
-  for(size_t i = 0; i < n; ++i) {
-    const reco::Candidate * d = (const_cast<const reco::Candidate &>(c)).daughter(i);
-    p4 += d->p4();
-    charge += d->charge();
+  double transverseMass(const reco::Candidate::LorentzVector& p1,
+                        const reco::Candidate::LorentzVector& p2){
+    double totalEt = p1.Et() + p2.Et();
+    double totalPt = (p1 + p2).pt();
+    double mt2 = totalEt*totalEt - totalPt*totalPt;
+    if (mt2 < 0) {
+      std::cout << "P1 = " << p1 << " P2 = " << p2 << " " << mt2 << std::endl;
+    }
+    return std::sqrt(std::abs(mt2));
   }
-  c.setP4( p4 );
-  c.setCharge( charge );
-}
 
-/// Helper function to get the matched gen particle 
-const reco::GenParticleRef getGenParticle(const reco::Candidate*   daughter, const reco::GenParticleRefProd genCollectionRef, int pdgIdToMatch, bool checkCharge)
-{
-  //if no genPaticle no matching
-  if(!genCollectionRef){
-    return reco::GenParticleRef();
+  // Taken from CommonTools/CandUtils/AddFourMomenta.h
+  void addFourMomenta( reco::Candidate & c ) {
+    reco::Candidate::LorentzVector p4( 0, 0, 0, 0 );
+    reco::Candidate::Charge charge = 0;
+    size_t n = c.numberOfDaughters();
+    for(size_t i = 0; i < n; ++i) {
+      const reco::Candidate * d = (const_cast<const reco::Candidate &>(c)).daughter(i);
+      p4 += d->p4();
+      charge += d->charge();
+    }
+    c.setP4( p4 );
+    c.setCharge( charge );
   }
-  reco::GenParticleCollection genParticles = *genCollectionRef;
 
-  //builds pset used by various subclasses
-  edm::ParameterSet pset;
-  pset.addParameter<double>("maxDPtRel", 0.5);
-  pset.addParameter<double>("maxDeltaR", 0.5);
-  std::vector<int> pdgIdsToMatch;
-  pdgIdsToMatch.push_back(pdgIdToMatch);
-  pset.addParameter<std::vector<int> >("mcPdgId", pdgIdsToMatch);
-  std::vector<int> status;
-  pdgIdsToMatch.push_back(1);
-  pset.addParameter<std::vector<int> >("mcStatus", status);
-  pset.addParameter<bool>("resolveByMatchQuality", false);
-  pset.addParameter<bool>("checkCharge", checkCharge);
-  pset.addParameter<bool>("resolveAmbiguities", true); //does not make any difference since we have no access to multiple candidates to match
+  /// Helper function to get the matched status 1 gen particle .
+  /// If preFSR is true, the last unbranched particle in the matched 
+  /// particle's chain is returned instead.
+  /// The preFSR option is not guaranteed to work for any generators
+  /// except Pythia 6 and Pythia 8.
+  const reco::GenParticleRef getGenParticle(const reco::Candidate*   daughter, 
+                                            const reco::GenParticleRefProd genCollectionRef, 
+                                            int pdgIdToMatch, bool checkCharge, 
+                                            bool preFSR)
+  {
+    //if no genPaticle no matching
+    if(!genCollectionRef){
+      return reco::GenParticleRef();
+    }
+    reco::GenParticleCollection genParticles = *genCollectionRef;
 
-  reco::MCMatchSelector<reco::Candidate, reco::GenParticle> slector(pset);
-  reco::MatchByDRDPt<reco::Candidate, reco::GenParticle> matcher(pset);
+    //builds pset used by various subclasses
+    edm::ParameterSet pset;
+    pset.addParameter<double>("maxDPtRel", 0.5);
+    pset.addParameter<double>("maxDeltaR", 0.5);
+    std::vector<int> pdgIdsToMatch;
+    pdgIdsToMatch.push_back(pdgIdToMatch);
+    pset.addParameter<std::vector<int> >("mcPdgId", pdgIdsToMatch);
+    std::vector<int> status;
+    status.push_back(1);
+    pset.addParameter<std::vector<int> >("mcStatus", status);
+    pset.addParameter<bool>("resolveByMatchQuality", false);
+    pset.addParameter<bool>("checkCharge", checkCharge);
+    pset.addParameter<bool>("resolveAmbiguities", true); //does not make any difference since we have no access to multiple candidates to match
 
-  //copied from CommonTools/ UtilAlgos/ interface/ PhysObjectMatcher.h
-  typedef std::pair<size_t, size_t> IndexPair;
-  typedef std::vector<IndexPair> MatchContainer;
+    reco::MCMatchSelector<reco::Candidate, reco::GenParticle> slector(pset);
+    reco::MatchByDRDPt<reco::Candidate, reco::GenParticle> matcher(pset);
 
-  // loop over (one in my case) candidates
-  int index = -1;
-  double minDr = 9999;
-  // loop over target collection
-  for(size_t m = 0; m != genParticles.size(); ++m) {
-    const reco::GenParticle& match = genParticles[m];
-    // check lock and preselection
-    if ( slector(*daughter, match) ) {
-      // matching requirement fulfilled -> store pair of indices
-      if ( matcher(*daughter,match) )  {
-	double curDr = reco::deltaR(*daughter,match);
-	if(curDr < minDr){
-	  minDr = curDr;
-	  index = m;
-	}
+    //copied from CommonTools/ UtilAlgos/ interface/ PhysObjectMatcher.h
+    typedef std::pair<size_t, size_t> IndexPair;
+    typedef std::vector<IndexPair> MatchContainer;
+
+    // loop over (one in my case) candidates
+    int index = -1;
+    double minDr = 9999;
+    // loop over target collection
+    for(size_t m = 0; m != genParticles.size(); ++m) {
+      const reco::GenParticle& match = genParticles[m];
+      // check lock and preselection
+      if ( slector(*daughter, match) ) {
+        // matching requirement fulfilled -> store pair of indices
+        if ( matcher(*daughter,match) )  {
+          double curDr = reco::deltaR(*daughter,match);
+          if(curDr < minDr){
+            minDr = curDr;
+            index = m;
+          }
+        }
       }
     }
-  }
 
-  // if match(es) found and no global ambiguity resolution requested
-  if(index != -1){
-    return reco::GenParticleRef(genCollectionRef,index);
-  }
-  //No Match found
-  else{
-    return reco::GenParticleRef();
-  }
-
-
-}
-
-/// Helper function to get the first interesting mother particle 
-const reco::GenParticleRef getMotherSmart(const reco::GenParticleRef genPart, int idNOTtoMatch)
-{
-  if( genPart->numberOfMothers() == 0 ) return genPart; // if we've recursed all the way back we need to stop
-
-  const reco::GenParticleRef mother = genPart->motherRef();
-  if( !(mother.isAvailable() && mother.isNonnull())  ) return mother;
-  if( mother.isAvailable() && mother.isNonnull() && mother->status() == 3 && mother->pdgId() != idNOTtoMatch )
-    return mother;
-  else
-    return getMotherSmart(mother, idNOTtoMatch);
-}
-
-const bool comesFromHiggs(const reco::GenParticleRef genPart)
-{
-  //std::cout << "comesFromHiggs::start" << std::endl;
-  if( genPart->numberOfMothers() >= 1 ){
-    const reco::GenParticleRef mother = /*dynamic_cast<reco::GenParticleRef>*/ (genPart->motherRef());
-    //std::cout << "comesFromHiggs::if statements" << std::endl;
-    if( !(mother.isAvailable() && mother.isNonnull()) ){
-      //std::cout << "comesFromHiggs::ret false" << std::endl;
-      return false;
+    reco::GenParticleRef out = reco::GenParticleRef();
+    if(index != -1){
+      out = reco::GenParticleRef(genCollectionRef,index);
     }
-    if( mother.isAvailable() && mother.isNonnull() && (mother->pdgId() == 25 || mother->pdgId() == 35 ) ){ // h^0 or H^0
-      //std::cout << "comesFromHiggs::ret true" << std::endl;
-      return true;
+    //No Match found
+    else{
+      return reco::GenParticleRef();
+    }
+
+    // if we want the equivalent particle from the hard scatter, loop back
+    // through particle's ancestry until we find it
+    // This is not a good way to do this, but the good way (commented below) doesn't exist in 7_2_X
+    if(preFSR)
+      {
+        // start at the top of the chain and work back down until we hit FSR or the end
+        bool checkNextMother = true;
+        while(checkNextMother)
+          {
+            checkNextMother = false;
+            for(size_t iM = 0; iM < out->numberOfMothers(); ++iM)
+              {
+                if(out->motherRef(iM).isAvailable() && 
+                   out->motherRef(iM).isNonnull() &&
+                   abs(out->motherRef(iM)->pdgId()) == pdgIdToMatch)
+                  {
+                    out = out->motherRef(iM);
+                    checkNextMother = true;
+                    break;
+                  }
+              }
+          }
+
+        // work back down
+        bool checkNextDaughter = true;
+        while(checkNextDaughter)
+          {
+            for(size_t iD = 0; iD < out->numberOfDaughters(); ++iD)
+              {
+                if(out->daughterRef(iD).isAvailable() && 
+                   out->daughterRef(iD).isNonnull() &&
+                   out->daughterRef(iD)->pdgId() == 22)
+                  {
+                    checkNextDaughter = false;
+                    break;
+                  }
+              }
+            
+            if(checkNextDaughter)
+              {
+                checkNextDaughter = false;
+                for(size_t iD = 0; iD < out->numberOfDaughters(); ++iD)
+                  {
+                    if(out->daughterRef(iD).isAvailable() && 
+                       out->daughterRef(iD).isNonnull() &&
+                       abs(out->daughterRef(iD)->pdgId()) == pdgIdToMatch)
+                      {
+                        out = out->daughterRef(iD);
+                        checkNextDaughter = true;
+                        break;
+                      }
+                  }
+              }
+          }
+      }
+
+    ///// This will be the correct way to do it in future verions of CMSSW. For now, dumb stuff.
+    // if(preFSR)
+    //   {
+    //     while(out->motherRef(0).isNonnull() && !(out->isLastCopyBeforeFSR()))
+    //       out = out->motherRef(0);
+    //   }
+
+    return out;
+    
+  }
+
+  /// Helper function to get the first interesting mother particle 
+  const reco::GenParticleRef getMotherSmart(const reco::GenParticleRef genPart, int idNOTtoMatch)
+  {
+    if( genPart->numberOfMothers() == 0 ) return genPart; // if we've recursed all the way back we need to stop
+
+    const reco::GenParticleRef mother = genPart->motherRef();
+    if( !(mother.isAvailable() && mother.isNonnull())  ) return mother;
+    if( mother.isAvailable() && mother.isNonnull() && mother->status() == 3 && mother->pdgId() != idNOTtoMatch )
+      return mother;
+    else
+      return getMotherSmart(mother, idNOTtoMatch);
+  }
+
+  const bool comesFromHiggs(const reco::GenParticleRef genPart)
+  {
+    //std::cout << "comesFromHiggs::start" << std::endl;
+    if( genPart->numberOfMothers() >= 1 ){
+      const reco::GenParticleRef mother = /*dynamic_cast<reco::GenParticleRef>*/ (genPart->motherRef());
+      //std::cout << "comesFromHiggs::if statements" << std::endl;
+      if( !(mother.isAvailable() && mother.isNonnull()) ){
+        //std::cout << "comesFromHiggs::ret false" << std::endl;
+        return false;
+      }
+      if( mother.isAvailable() && mother.isNonnull() && (mother->pdgId() == 25 || mother->pdgId() == 35 ) ){ // h^0 or H^0
+        //std::cout << "comesFromHiggs::ret true" << std::endl;
+        return true;
+      }
+      else{
+        //std::cout << "comesFromHiggs::ret recursive" << std::endl;
+        return comesFromHiggs(mother);
+      }
     }
     else{
-      //std::cout << "comesFromHiggs::ret recursive" << std::endl;
-      return comesFromHiggs(mother);
+      //std::cout << "comesFromHiggs::ret false from no mother" << std::endl;
+      return false;
     }
   }
-  else{
-    //std::cout << "comesFromHiggs::ret false from no mother" << std::endl;
-    return false;
-  }
-}
 
-const reco::Candidate::LorentzVector metPhiCorrection(const reco::Candidate::LorentzVector& vector, int nvertices, bool isMC)
-{
-  //ReReco data / Summer'12 MC + Summer'13 JEC Type1 PFMET
-  const double cx0 = (isMC) ? +1.62861e-01 : +4.83642e-02;  // 0.1166 :  0.2661;
-  const double cxS = (isMC) ? -2.38517e-02 : +2.48870e-01;  // 0.0200 :  0.3217;
-  const double cy0 = (isMC) ? +3.60860e-01 : -1.50135e-01;  // 0.2764 : -0.2251;
-  const double cyS = (isMC) ? -1.30335e-01 : -8.27917e-02;  //-0.1280 : -0.1747;
+  const reco::Candidate::LorentzVector metPhiCorrection(const reco::Candidate::LorentzVector& vector, int nvertices, bool isMC)
+  {
+    //ReReco data / Summer'12 MC + Summer'13 JEC Type1 PFMET
+    const double cx0 = (isMC) ? +1.62861e-01 : +4.83642e-02;  // 0.1166 :  0.2661;
+    const double cxS = (isMC) ? -2.38517e-02 : +2.48870e-01;  // 0.0200 :  0.3217;
+    const double cy0 = (isMC) ? +3.60860e-01 : -1.50135e-01;  // 0.2764 : -0.2251;
+    const double cyS = (isMC) ? -1.30335e-01 : -8.27917e-02;  //-0.1280 : -0.1747;
 
-  double offset_x = cx0 + cxS*nvertices;
-  double offset_y = cy0 + cyS*nvertices;
+    double offset_x = cx0 + cxS*nvertices;
+    double offset_y = cy0 + cyS*nvertices;
 
-  double newx     = vector.x() - offset_x;
-  double newy     = vector.y() - offset_y;
-  double mag      = TMath::Sqrt(newx*newx + newy*newy);
+    double newx     = vector.x() - offset_x;
+    double newy     = vector.y() - offset_y;
+    double mag      = TMath::Sqrt(newx*newx + newy*newy);
 
-  //the vector is made in pt eta phi e coordinates!
-  return reco::Candidate::LorentzVector(newx, newy, 0., mag);
-}
-
-const bool findDecay(const reco::GenParticleRefProd genCollectionRef, int pdgIdMother, int pdgIdDaughter)
-{
-  //if no genPaticle no matching
-  if(!genCollectionRef){
-    return false;
-  }
-  reco::GenParticleCollection genParticles = *genCollectionRef;
-  reco::GenParticleRefVector allMothers;  
-  GenParticlesHelper::findParticles( *genCollectionRef,     
-		 allMothers, std::abs(pdgIdMother), 2);
-  GenParticlesHelper::findParticles( *genCollectionRef,     
-		 allMothers, std::abs(pdgIdMother), 3);
-
-  reco::GenParticleRefVector descendents;
-  for ( GenParticlesHelper::IGR iMom = allMothers.begin(); iMom != allMothers.end(); ++iMom ) {
-    GenParticlesHelper::findDescendents( *iMom, descendents, 2, std::abs(pdgIdDaughter)); //Might not be stable, but it's fine
-    GenParticlesHelper::findDescendents( *iMom, descendents, 3, std::abs(pdgIdDaughter)); //Might not be stable, but it's fine
+    //the vector is made in pt eta phi e coordinates!
+    return reco::Candidate::LorentzVector(newx, newy, 0., mag);
   }
 
-  return (descendents.size() > 0);
-}
-
-
-float jetQGVariables(const reco::CandidatePtr  jetptr, const std::string& myvar, const edm::PtrVector<reco::Vertex> recoVertices)
-{
-  //std::map <std::string, float> varMap; 
-  const pat::Jet *jet = dynamic_cast<const pat::Jet*> (jetptr.get());
-  if (myvar == "eta")
-    return jet->eta();
-  Bool_t useQC = true;
-  // if(fabs(jet->eta()) > 2.5 && type == "MLP") useQC = false;		//In MLP: no QC in forward region
-
-  edm::PtrVector<reco::Vertex>::const_iterator vtxLead = recoVertices.begin();
-
-  Float_t sum_weight = 0., sum_deta = 0., sum_dphi = 0., sum_deta2 = 0., sum_dphi2 = 0., sum_detadphi = 0., sum_pt = 0.;
-  Int_t nChg_QC = 0, nChg_ptCut = 0, nNeutral_ptCut = 0;
-
-  //Loop over the jet constituents
-  std::vector<reco::PFCandidatePtr> constituents = jet->getPFConstituents();
-  for(unsigned i = 0; i < constituents.size(); ++i){
-    reco::PFCandidatePtr part = jet->getPFConstituent(i);      
-    if(!part.isNonnull()) continue;
-    
-    reco::TrackRef itrk = part->trackRef();
-    
-    bool trkForAxis = false;
-    if(itrk.isNonnull()){						//Track exists --> charged particle
-      if(part->pt() > 1.0) nChg_ptCut++;
-  	
-      //Search for closest vertex to track
-      edm::PtrVector<reco::Vertex>::const_iterator  vtxClose = recoVertices.begin();
-      for( edm::PtrVector<reco::Vertex>::const_iterator  vtx = recoVertices.begin(); vtx != recoVertices.end(); ++vtx){
-	if(fabs(itrk->dz((*vtx)->position())) < fabs(itrk->dz((*vtxClose)->position()))) vtxClose = vtx;
-      }
-  	
-      if(vtxClose == vtxLead){
-	Float_t dz = itrk->dz((*vtxClose)->position());
-	Float_t dz_sigma = sqrt(pow(itrk->dzError(),2) + pow((*vtxClose)->zError(),2));
-  	
-	if(itrk->quality(reco::TrackBase::qualityByName("highPurity")) && fabs(dz/dz_sigma) < 5.){
-	  trkForAxis = true;
-	  Float_t d0 = itrk->dxy((*vtxClose)->position());
-	  Float_t d0_sigma = sqrt(pow(itrk->d0Error(),2) + pow((*vtxClose)->xError(),2) + pow((*vtxClose)->yError(),2));
-	  if(fabs(d0/d0_sigma) < 5.) nChg_QC++;
-	}
-      }
-    } else {								//No track --> neutral particle
-      if(part->pt() > 1.0) nNeutral_ptCut++;
-      trkForAxis = true;
+  const bool findDecay(const reco::GenParticleRefProd genCollectionRef, int pdgIdMother, int pdgIdDaughter)
+  {
+    //if no genPaticle no matching
+    if(!genCollectionRef){
+      return false;
     }
-    
-    Float_t deta = part->eta() - jet->eta();
-    Float_t dphi = 2*atan(tan(((part->phi()- jet->phi()))/2));           
-    Float_t partPt = part->pt(); 
-    Float_t weight = partPt*partPt;
+    reco::GenParticleCollection genParticles = *genCollectionRef;
+    reco::GenParticleRefVector allMothers;  
+    GenParticlesHelper::findParticles( *genCollectionRef,     
+                                       allMothers, std::abs(pdgIdMother), 2);
+    GenParticlesHelper::findParticles( *genCollectionRef,     
+                                       allMothers, std::abs(pdgIdMother), 3);
 
-    if(!useQC || trkForAxis){					//If quality cuts, only use when trkForAxis
-      sum_weight += weight;
-      sum_pt += partPt;
-      sum_deta += deta*weight;                  
-      sum_dphi += dphi*weight;                                                                                             
-      sum_deta2 += deta*deta*weight;                    
-      sum_detadphi += deta*dphi*weight;                               
-      sum_dphi2 += dphi*dphi*weight;
-    }	
+    reco::GenParticleRefVector descendents;
+    for ( GenParticlesHelper::IGR iMom = allMothers.begin(); iMom != allMothers.end(); ++iMom ) {
+      GenParticlesHelper::findDescendents( *iMom, descendents, 2, std::abs(pdgIdDaughter)); //Might not be stable, but it's fine
+      GenParticlesHelper::findDescendents( *iMom, descendents, 3, std::abs(pdgIdDaughter)); //Might not be stable, but it's fine
+    }
+
+    return (descendents.size() > 0);
   }
 
-  //Calculate axis and ptD
-  Float_t a = 0., b = 0., c = 0.;
-  Float_t ave_deta = 0., ave_dphi = 0., ave_deta2 = 0., ave_dphi2 = 0.;
-  if(sum_weight > 0){
-    if (myvar == "ptD")
-      return sqrt(sum_weight)/sum_pt;
-    ave_deta = sum_deta/sum_weight;
-    ave_dphi = sum_dphi/sum_weight;
-    ave_deta2 = sum_deta2/sum_weight;
-    ave_dphi2 = sum_dphi2/sum_weight;
-    a = ave_deta2 - ave_deta*ave_deta;                          
-    b = ave_dphi2 - ave_dphi*ave_dphi;                          
-    c = -(sum_detadphi/sum_weight - ave_deta*ave_dphi);                
-  } 
-  else if(myvar == "ptD")
-    return 0;
-  Float_t delta = sqrt(fabs((a-b)*(a-b)+4*c*c));
+
+  float jetQGVariables(const reco::CandidatePtr  jetptr, const std::string& myvar, const edm::PtrVector<reco::Vertex> recoVertices)
+  {
+    //std::map <std::string, float> varMap; 
+    const pat::Jet *jet = dynamic_cast<const pat::Jet*> (jetptr.get());
+    if (myvar == "eta")
+      return jet->eta();
+    Bool_t useQC = true;
+    // if(fabs(jet->eta()) > 2.5 && type == "MLP") useQC = false;		//In MLP: no QC in forward region
+
+    edm::PtrVector<reco::Vertex>::const_iterator vtxLead = recoVertices.begin();
+
+    Float_t sum_weight = 0., sum_deta = 0., sum_dphi = 0., sum_deta2 = 0., sum_dphi2 = 0., sum_detadphi = 0., sum_pt = 0.;
+    Int_t nChg_QC = 0, nChg_ptCut = 0, nNeutral_ptCut = 0;
+
+    //Loop over the jet constituents
+    std::vector<reco::PFCandidatePtr> constituents = jet->getPFConstituents();
+    for(unsigned i = 0; i < constituents.size(); ++i){
+      reco::PFCandidatePtr part = jet->getPFConstituent(i);      
+      if(!part.isNonnull()) continue;
+    
+      reco::TrackRef itrk = part->trackRef();
+    
+      bool trkForAxis = false;
+      if(itrk.isNonnull()){						//Track exists --> charged particle
+        if(part->pt() > 1.0) nChg_ptCut++;
+  	
+        //Search for closest vertex to track
+        edm::PtrVector<reco::Vertex>::const_iterator  vtxClose = recoVertices.begin();
+        for( edm::PtrVector<reco::Vertex>::const_iterator  vtx = recoVertices.begin(); vtx != recoVertices.end(); ++vtx){
+          if(fabs(itrk->dz((*vtx)->position())) < fabs(itrk->dz((*vtxClose)->position()))) vtxClose = vtx;
+        }
+  	
+        if(vtxClose == vtxLead){
+          Float_t dz = itrk->dz((*vtxClose)->position());
+          Float_t dz_sigma = sqrt(pow(itrk->dzError(),2) + pow((*vtxClose)->zError(),2));
+  	
+          if(itrk->quality(reco::TrackBase::qualityByName("highPurity")) && fabs(dz/dz_sigma) < 5.){
+            trkForAxis = true;
+            Float_t d0 = itrk->dxy((*vtxClose)->position());
+            Float_t d0_sigma = sqrt(pow(itrk->d0Error(),2) + pow((*vtxClose)->xError(),2) + pow((*vtxClose)->yError(),2));
+            if(fabs(d0/d0_sigma) < 5.) nChg_QC++;
+          }
+        }
+      } else {								//No track --> neutral particle
+        if(part->pt() > 1.0) nNeutral_ptCut++;
+        trkForAxis = true;
+      }
+    
+      Float_t deta = part->eta() - jet->eta();
+      Float_t dphi = 2*atan(tan(((part->phi()- jet->phi()))/2));           
+      Float_t partPt = part->pt(); 
+      Float_t weight = partPt*partPt;
+
+      if(!useQC || trkForAxis){					//If quality cuts, only use when trkForAxis
+        sum_weight += weight;
+        sum_pt += partPt;
+        sum_deta += deta*weight;                  
+        sum_dphi += dphi*weight;                                                                                             
+        sum_deta2 += deta*deta*weight;                    
+        sum_detadphi += deta*dphi*weight;                               
+        sum_dphi2 += dphi*dphi*weight;
+      }	
+    }
+
+    //Calculate axis and ptD
+    Float_t a = 0., b = 0., c = 0.;
+    Float_t ave_deta = 0., ave_dphi = 0., ave_deta2 = 0., ave_dphi2 = 0.;
+    if(sum_weight > 0){
+      if (myvar == "ptD")
+        return sqrt(sum_weight)/sum_pt;
+      ave_deta = sum_deta/sum_weight;
+      ave_dphi = sum_dphi/sum_weight;
+      ave_deta2 = sum_deta2/sum_weight;
+      ave_dphi2 = sum_dphi2/sum_weight;
+      a = ave_deta2 - ave_deta*ave_deta;                          
+      b = ave_dphi2 - ave_dphi*ave_dphi;                          
+      c = -(sum_detadphi/sum_weight - ave_deta*ave_dphi);                
+    } 
+    else if(myvar == "ptD")
+      return 0;
+    Float_t delta = sqrt(fabs((a-b)*(a-b)+4*c*c));
   
-  if(myvar == "axis1")
-    return (a+b+delta > 0) ? sqrt(0.5*(a+b+delta)) : 0.;
-  else if(myvar == "axis2")
-    return (a+b-delta > 0) ? sqrt(0.5*(a+b-delta)) : 0.;
-  else if(myvar == "mult")
-    return (nChg_QC + nNeutral_ptCut);
-  else if(myvar == "mult_MLP_QC")
-    return (nChg_QC );
-  else if(myvar == "mult_MLP")
-    return (nChg_ptCut + nNeutral_ptCut );
+    if(myvar == "axis1")
+      return (a+b+delta > 0) ? sqrt(0.5*(a+b+delta)) : 0.;
+    else if(myvar == "axis2")
+      return (a+b-delta > 0) ? sqrt(0.5*(a+b-delta)) : 0.;
+    else if(myvar == "mult")
+      return (nChg_QC + nNeutral_ptCut);
+    else if(myvar == "mult_MLP_QC")
+      return (nChg_QC );
+    else if(myvar == "mult_MLP")
+      return (nChg_ptCut + nNeutral_ptCut );
   
-  return -1.;
-}
+    return -1.;
+  }
 
 }

--- a/DataFormats/interface/PATFinalState.h
+++ b/DataFormats/interface/PATFinalState.h
@@ -293,7 +293,7 @@ class PATFinalState : public pat::PATObject<reco::LeafCandidate> {
         size_t i, const std::string& label) const = 0;
 
     /// Get the specified overlaps for the ith daughter
-    const reco::GenParticleRef getDaughterGenParticle(size_t i, int pdgIdToMatch, int checkCharge) const;
+    const reco::GenParticleRef getDaughterGenParticle(size_t i, int pdgIdToMatch, int checkCharge, int preFSR=0) const;
     const reco::GenParticleRef getDaughterGenParticleMotherSmart(size_t i, int pdgIdToMatch, int checkCharge) const;
     const bool comesFromHiggs(size_t i, int pdgIdToMatch, int checkCharge) const;
 

--- a/DataFormats/src/PATFinalState.cc
+++ b/DataFormats/src/PATFinalState.cc
@@ -852,9 +852,10 @@ edm::Ptr<pat::Photon> PATFinalState::daughterAsPhoton(size_t i) const {
   return daughterAs<pat::Photon>(i);
 }
 
-const reco::GenParticleRef PATFinalState::getDaughterGenParticle(size_t i, int pdgIdToMatch, int checkCharge) const {
+const reco::GenParticleRef PATFinalState::getDaughterGenParticle(size_t i, int pdgIdToMatch, int checkCharge, int preFSR) const {
   bool charge = (bool) checkCharge;
-  return fshelpers::getGenParticle( daughter(i), event_->genParticleRefProd(), pdgIdToMatch, charge);
+  bool pFSR = (bool) preFSR;
+  return fshelpers::getGenParticle( daughter(i), event_->genParticleRefProd(), pdgIdToMatch, charge, pFSR);
 }
 
 const reco::GenParticleRef PATFinalState::getDaughterGenParticleMotherSmart(size_t i, int pdgIdToMatch, int checkCharge) const {

--- a/NtupleTools/python/object_parameter_selector.py
+++ b/NtupleTools/python/object_parameter_selector.py
@@ -103,6 +103,6 @@ def setup_selections(process, moduleName, inputs, params):
         seq += module
 
         # use the correct name for this object if it's needed by other selector modules
-        inputs[obj] = getName(obj)+moduleName
+        inputs[getName(obj)+"s"] = getName(obj)+moduleName
 
     return seq

--- a/recipe/environment.sh
+++ b/recipe/environment.sh
@@ -42,12 +42,12 @@ if [ -d "$vpython" ]; then
   # See https://github.com/pypa/virtualenv/issues/150
   source bin/activate
   cd -
+  # Make sure we prefer our virtualenv packages
+  export PYTHONPATH=$fsa/recipe/external/vpython/lib/python2.7/site-packages/:$PYTHONPATH
 fi
 
 # Put the PWD into the PYTHONPATH
 export PYTHONPATH=.:$PYTHONPATH
-# Make sure we prefer our virtualenv packages
-export PYTHONPATH=$fsa/recipe/external/vpython/lib/python2.6/site-packages/:$PYTHONPATH
 
 if [ -d "$hdf5" ]
 then

--- a/recipe/recipe_13TeV.sh
+++ b/recipe/recipe_13TeV.sh
@@ -43,12 +43,12 @@ pushd $CMSSW_BASE/src/EgammaAnalysis/ElectronTools/data
 cat download.url | xargs wget
 popd
 
-echo "Checking out recipe for mvamet"
-# https://twiki.cern.ch/twiki/bin/viewauth/CMS/MVAMet#CMSSW_7_2_X_requires_slc6_MiniAO
-git-cms-merge-topic -u cms-met:72X-13TeV-Training-30Jan15
-pushd $CMSSW_BASE/src/RecoMET/METPUSubtraction
-git clone https://github.com/rfriese/RecoMET-METPUSubtraction data -b 72X-13TeV-Phys14_25_V4-26Mar15
-popd
+# echo "Checking out recipe for mvamet"
+# # https://twiki.cern.ch/twiki/bin/viewauth/CMS/MVAMet#CMSSW_7_2_X_requires_slc6_MiniAO
+# git-cms-merge-topic -u cms-met:72X-13TeV-Training-30Jan15
+# pushd $CMSSW_BASE/src/RecoMET/METPUSubtraction
+# git clone https://github.com/rfriese/RecoMET-METPUSubtraction data -b 72X-13TeV-Phys14_25_V4-26Mar15
+# popd
 
 # HZZ MELA, MEKD etc.
 if [ "$HZZ" = "1" ]; then


### PR DESCRIPTION
Due to a goofy little bug that seems to have been in the code for many years, rather than requiring reco particles be matched to status 1 gen particles only, the gen matching helper put no requirement on status, but allowed any particle to be matched to gen particles with PDG ID 1. I don't think it's a big deal, because non-status-1 gen particles are probably pretty close to the status 1 particles we wanted, and color confinement keeps you from having too many down quarks flying around. 

While I was at it, I added an option to the gen matcher that allows you to match to a status 1 particle, but instead return its latest pre-FSR ancestor. Right now, the default is to use the status 1 particle, so this option should be transparent to anybody who doesn't use it on purpose (unlike the status/PDG ID fix).

I got annoyed with whitespace issues in two files and had emacs redo it all for me, sorry for the ungainly diffs below. You can have GitHub Unified Diff ignore whitespace changes by adding `?w=1` to the end of the URL of the page you're looking at.
