### PR TITLE
metaInfo fix

### DIFF
--- a/MetaData/tuples/MiniAOD-13TeV_Data.json
+++ b/MetaData/tuples/MiniAOD-13TeV_Data.json
@@ -1,0 +1,7 @@
+{
+  "data_DoubleMuon_Run2015B_PromptReco_50ns" : "/DoubleMuon/Run2015B-PromptReco-v1/MINIAOD",
+  "data_MuonEG_Run2015B_PromptReco_50ns" : "/MuonEG/Run2015B-PromptReco-v1/MINIAOD",
+  "data_DoubleEG_Run2015B_PromptReco_50ns" : "/DoubleEG/Run2015B-PromptReco-v1/MINIAOD"
+}
+
+

--- a/MetaData/tuples/MiniAOD-13TeV_RunIISpring15DR74.json
+++ b/MetaData/tuples/MiniAOD-13TeV_RunIISpring15DR74.json
@@ -1,4 +1,8 @@
 {
+  "data_DoubleMuon_Run2015B_PromptReco_50ns" : "/DoubleMuon/Run2015B-PromptReco-v1/MINIAOD",
+  "data_MuonEG_Run2015B_PromptReco_50ns" : "/MuonEG/Run2015B-PromptReco-v1/MINIAOD",
+  "data_DoubleEG_Run2015B_PromptReco_50ns" : "/DoubleEG/Run2015B-PromptReco-v1/MINIAOD",
+
   "DYJetsToLL_M-10to50" : "DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8",
   "DYJetsToLL_M-50" : "DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8",
 

--- a/NtupleTools/interface/PATFinalStateAnalysis.h
+++ b/NtupleTools/interface/PATFinalStateAnalysis.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <map>
 #include <boost/shared_ptr.hpp>
+#include <iostream>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"

--- a/NtupleTools/python/ntuple_builder.py
+++ b/NtupleTools/python/ntuple_builder.py
@@ -394,7 +394,7 @@ def make_ntuple(*legs, **kwargs):
         src=cms.InputTag( analyzerSrc ),
         evtSrc=cms.InputTag("patFinalStateEventProducer"),
         # counter of events before any selections
-        skimCounter=cms.InputTag("eventCount", "", "TUPLE"),
+        skimCounter=cms.InputTag("eventCount"),
         analysis=cms.PSet(
             selections=cms.VPSet(),
             EventView=cms.bool(False),

--- a/NtupleTools/src/PATFinalStateAnalysis.cc
+++ b/NtupleTools/src/PATFinalStateAnalysis.cc
@@ -59,6 +59,7 @@ PATFinalStateAnalysis::PATFinalStateAnalysis(
   metaTree_->Branch("run", &treeRunBranch_, "run/I");
   metaTree_->Branch("lumi", &treeLumiBranch_, "lumi/I");
   metaTree_->Branch("nevents", &treeEventsProcessedBranch_, "nevents/I");
+
 }
 
 PATFinalStateAnalysis::~PATFinalStateAnalysis() { }

--- a/NtupleTools/test/make_ntuples_cfg.py
+++ b/NtupleTools/test/make_ntuples_cfg.py
@@ -265,6 +265,7 @@ process.miniAODElectronEAEmbedding = cms.EDProducer(
     "MiniAODElectronEffectiveArea2015Embedder",
     src = cms.InputTag(fs_daughter_inputs['electrons']),
     label = cms.string("EffectiveArea_HZZ4l2015"), # embeds a user float with this name
+    use25ns = cms.bool(bool(options.use25ns)),
     )
 fs_daughter_inputs['electrons'] = 'miniAODElectronEAEmbedding'
 process.EAEmbedding = cms.Path(

--- a/NtupleTools/test/make_ntuples_cfg.py
+++ b/NtupleTools/test/make_ntuples_cfg.py
@@ -178,6 +178,14 @@ process.GlobalTag.globaltag = cms.string(GT[envvar])
 
 print 'Using globalTag: %s' % process.GlobalTag.globaltag
 
+# Count events at the beginning of the tuplization
+process.load("FinalStateAnalysis.RecoTools.eventCount_cfi")
+process.load("FinalStateAnalysis.PatTools.finalStates.patFinalStateLSProducer_cfi")
+process.generateMetaInfo = cms.Path(process.eventCount *
+                                    process.finalStateLS
+                                    )
+process.schedule.append(process.generateMetaInfo)
+
 # Drop the input ones, just to make sure we aren't screwing anything up
 process.buildFSASeq = cms.Sequence()
 from FinalStateAnalysis.PatTools.patFinalStateProducers \
@@ -194,6 +202,7 @@ fs_daughter_inputs = {
     'fsr': 'slimmedPhotons',
     'vertices': 'offlineSlimmedPrimaryVertices',
 }
+
 
 ### embed some things we need that arent in miniAOD (ids, etc.)
 

--- a/NtupleTools/test/make_ntuples_cfg.py
+++ b/NtupleTools/test/make_ntuples_cfg.py
@@ -150,20 +150,21 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 # Need the global tag for geometry etc.
 envvar = 'mcgt' if options.isMC else 'datagt'
-GT = {'mcgt': 'MCRUN2_74_V9A::All', 'datagt': 'GR_70_V2_AN1::All'}
+GT = {'mcgt': 'MCRUN2_74_V9A', 'datagt': '74X_dataRun2_Prompt_v0'}
 if options.use25ns:
-    GT['mcgt'] = 'MCRUN2_74_V9::All'
+    GT['mcgt'] = 'MCRUN2_74_V9'
 
 
-if options.GlobalTag:
-    process.GlobalTag.globaltag = cms.string(options.GlobalTag)
-else:
-    try:
-        process.GlobalTag.globaltag = cms.string(os.environ[envvar])
-    except KeyError:
-        print 'Warning: GlobalTag not defined in environment. Using default.'
-        process.GlobalTag.globaltag = cms.string(GT[envvar])
-    process.GlobalTag.globaltag = cms.string(GT[envvar])
+#if options.GlobalTag:
+#    process.GlobalTag.globaltag = cms.string(options.GlobalTag)
+#else:
+#    try:
+#        process.GlobalTag.globaltag = cms.string(os.environ[envvar])
+#    except KeyError:
+#        print 'Warning: GlobalTag not defined in environment. Using default.'
+#        process.GlobalTag.globaltag = cms.string(GT[envvar])
+#    process.GlobalTag.globaltag = cms.string(GT[envvar])
+process.GlobalTag.globaltag = cms.string(GT[envvar])
 
 print 'Using globalTag: %s' % process.GlobalTag.globaltag
 

--- a/NtupleTools/test/make_ntuples_cfg.py
+++ b/NtupleTools/test/make_ntuples_cfg.py
@@ -144,13 +144,13 @@ process.maxEvents = cms.untracked.PSet(
 process.schedule = cms.Schedule()
 
 #load magfield and geometry (for mass resolution)
-process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.Geometry.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.MagneticField_38T_cff')
-process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
 
 # Need the global tag for geometry etc.
 envvar = 'mcgt' if options.isMC else 'datagt'
-GT = {'mcgt': 'MCRUN2_74_V9A', 'datagt': '74X_dataRun2_Prompt_v0'}
+GT = {'mcgt': 'MCRUN2_74_V9A', 'datagt': 'GR_P_V56'}
 if options.use25ns:
     GT['mcgt'] = 'MCRUN2_74_V9'
 

--- a/PatTools/plugins/MiniAODElectronEffectiveArea2015Embedder.cc
+++ b/PatTools/plugins/MiniAODElectronEffectiveArea2015Embedder.cc
@@ -40,13 +40,14 @@ private:
   virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup);
   virtual void endJob();
 
-  float getEA2015(const edm::Ptr<pat::Electron>& elec) const;
+  float getEA2015_25ns(const edm::Ptr<pat::Electron>& elec) const;
+  float getEA2015_50ns(const edm::Ptr<pat::Electron>& elec) const;
 
   // Data
   edm::EDGetTokenT<edm::View<pat::Electron> > electronCollectionToken_;
-  std::string label_; // label for the embedded userfloat
+  const std::string label_; // label for the embedded userfloat
   std::auto_ptr<std::vector<pat::Electron> > out; // Collection we'll output at the end
-
+  const bool use25ns_;
 };
 
 
@@ -58,7 +59,10 @@ MiniAODElectronEffectiveArea2015Embedder::MiniAODElectronEffectiveArea2015Embedd
                                                                edm::InputTag("slimmedElectrons"))),
   label_(iConfig.exists("label") ?
 	 iConfig.getParameter<std::string>("label") :
-	 std::string("EffectiveArea_HZZ4l2015"))
+	 std::string("EffectiveArea_HZZ4l2015")),
+  use25ns_(iConfig.exists("use25ns") ?
+	   iConfig.getParameter<bool>("use25ns") :
+	   true)
 {
   produces<std::vector<pat::Electron> >();
 }
@@ -79,7 +83,12 @@ void MiniAODElectronEffectiveArea2015Embedder::produce(edm::Event& iEvent, const
 
       out->push_back(*ei); // copy electron to save correctly in event
 
-      float ea = getEA2015(eptr);
+      float ea;
+      if(use25ns_)
+	ea = getEA2015_25ns(eptr);
+      else
+	ea = getEA2015_50ns(eptr);
+	
       out->back().addUserFloat(label_, ea);
     }
 
@@ -87,7 +96,25 @@ void MiniAODElectronEffectiveArea2015Embedder::produce(edm::Event& iEvent, const
 }
 
 
-float MiniAODElectronEffectiveArea2015Embedder::getEA2015(const edm::Ptr<pat::Electron>& elec) const
+
+float MiniAODElectronEffectiveArea2015Embedder::getEA2015_25ns(const edm::Ptr<pat::Electron>& elec) const
+{
+  float eta = fabs(elec->eta());
+
+  if(eta >= 2.2)
+    return 0.2680;
+  else if(eta >= 2.0)
+    return 0.1565;
+  else if(eta >= 1.3)
+    return 0.1077;
+  else if(eta >= 0.8)
+    return 0.1734;
+  else
+    return 0.1830;
+}
+
+
+float MiniAODElectronEffectiveArea2015Embedder::getEA2015_50ns(const edm::Ptr<pat::Electron>& elec) const
 {
   float eta = fabs(elec->eta());
 

--- a/PatTools/plugins/PATFinalStateAnalysisFilter.cc
+++ b/PatTools/plugins/PATFinalStateAnalysisFilter.cc
@@ -5,30 +5,33 @@
  * Author: Evan K. Friis UW Madison
  */
 
+#include <iostream>
+
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Common/interface/LuminosityBlockBase.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/one/EDFilter.h"
+#include "FWCore/Framework/interface/one/filterAbilityToImplementor.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "CommonTools/Utils/interface/TFileDirectory.h"
 
 #include "FinalStateAnalysis/NtupleTools/interface/PATFinalStateAnalysis.h"
 
-class PATFinalStateAnalysisFilter : public edm::EDFilter {
+class PATFinalStateAnalysisFilter : public edm::one::EDFilter<edm::one::WatchLuminosityBlocks> {
   public:
     PATFinalStateAnalysisFilter(const edm::ParameterSet& pset);
     virtual ~PATFinalStateAnalysisFilter(){}
     void beginJob();
     void endJob();
     bool filter(edm::Event& evt, const edm::EventSetup& es);
-    bool beginLuminosityBlock(
-        edm::LuminosityBlock& ls, const edm::EventSetup & es);
-    bool endLuminosityBlock(
-        edm::LuminosityBlock& ls, const edm::EventSetup & es);
+    void beginLuminosityBlock(edm::LuminosityBlock const& ls, 
+				     edm::EventSetup const& es) override;
+    void endLuminosityBlock(edm::LuminosityBlock const& ls, 
+				   edm::EventSetup const& es) override;
   private:
     std::auto_ptr<PATFinalStateAnalysis> analysis_;
 };
@@ -38,6 +41,7 @@ PATFinalStateAnalysisFilter::PATFinalStateAnalysisFilter(
   edm::Service<TFileService> fs;
   TFileDirectory &fd =  fs->tFileDirectory();
   analysis_.reset(new PATFinalStateAnalysis(pset, fd));
+
 }
 
 bool PATFinalStateAnalysisFilter::filter(
@@ -46,18 +50,18 @@ bool PATFinalStateAnalysisFilter::filter(
   return analysis_->filter(evtBase);
 }
 
-bool PATFinalStateAnalysisFilter::beginLuminosityBlock(
-    edm::LuminosityBlock& ls, const edm::EventSetup& es) {
+void PATFinalStateAnalysisFilter::beginLuminosityBlock(
+    edm::LuminosityBlock const& ls, edm::EventSetup const& es) {
+
   const edm::LuminosityBlockBase& lsBase = ls;
   analysis_->beginLuminosityBlock(lsBase);
-  return true;
 }
 
-bool PATFinalStateAnalysisFilter::endLuminosityBlock(
-    edm::LuminosityBlock& ls, const edm::EventSetup& es) {
+void PATFinalStateAnalysisFilter::endLuminosityBlock(
+    edm::LuminosityBlock const& ls, edm::EventSetup const& es) {
   const edm::LuminosityBlockBase& lsBase = ls;
+
   analysis_->endLuminosityBlock(lsBase);
-  return true;
 }
 
 void PATFinalStateAnalysisFilter::beginJob() {

--- a/PatTools/plugins/PATFinalStateLSProducer.cc
+++ b/PatTools/plugins/PATFinalStateLSProducer.cc
@@ -11,18 +11,19 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/one/producerAbilityToImplementor.h"
 
 #include "FinalStateAnalysis/DataFormats/interface/PATFinalStateLS.h"
 #include "DataFormats/PatCandidates/interface/TriggerEvent.h"
 
-class PATFinalStateLSProducer : public edm::EDProducer {
+class PATFinalStateLSProducer : public edm::one::EDProducer<edm::EndLuminosityBlockProducer> {
   public:
     PATFinalStateLSProducer(const edm::ParameterSet& pset);
     virtual ~PATFinalStateLSProducer(){}
     void produce(edm::Event& evt, const edm::EventSetup& es);
-    void endLuminosityBlock(
-        edm::LuminosityBlock& ls, const edm::EventSetup& es);
+    void endLuminosityBlockProduce(
+        edm::LuminosityBlock& ls, edm::EventSetup const& es);
   private:
     const edm::InputTag trigSrc_;
     // For MC
@@ -48,8 +49,8 @@ PATFinalStateLSProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   eventCount_ += 1;
 }
 
-void PATFinalStateLSProducer::endLuminosityBlock(
-    edm::LuminosityBlock& ls, const edm::EventSetup& es) {
+void PATFinalStateLSProducer::endLuminosityBlockProduce(
+    edm::LuminosityBlock& ls, edm::EventSetup const& es) {
 
   double intgRecLumi = -999;
   double instLumi = -999;

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ PAT tuple, and utilities for generating plain ROOT ntuples from the PAT tuple.
 Installation
 ------------
 
-Current CMSSW version: ``7_4_5``.
+Current CMSSW version: ``7_4_7``.
 
 Get a supported CMSSW release area:
 

--- a/Utilities/scripts/submit_job.py
+++ b/Utilities/scripts/submit_job.py
@@ -113,16 +113,22 @@ def getFarmoutCommand(args, dataset_name, full_dataset_name):
     command.append("'inputFiles=$inputFileNames'")
     command.append("'outputFile=$outputFileName'")
 
-    if args.apply_cms_lumimask and 'lumi_mask' in sample_info:
-        lumi_mask_path = os.path.join(
-            os.environ['CMSSW_BASE'], 'src', sample_info['lumi_mask'])
+    # temp hardcode
+    if args.apply_cms_lumimask:
+        filename = 'DCSOnly/json_DCSONLY_Run2015B.txt'
+        lumi_mask_path = os.path.join('/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV',filename)
         command.append('lumiMask=%s' % lumi_mask_path)
-        firstRun = sample_info.get('firstRun', -1)
-        if firstRun > 0:
-            command.append('firstRun=%i' % firstRun)
-        lastRun = sample_info.get('lastRun', -1)
-        if lastRun > 0:
-            command.append('lastRun=%i' % lastRun)
+
+    #if args.apply_cms_lumimask and 'lumi_mask' in sample_info:
+    #    lumi_mask_path = os.path.join(
+    #        os.environ['CMSSW_BASE'], 'src', sample_info['lumi_mask'])
+    #    command.append('lumiMask=%s' % lumi_mask_path)
+    #    firstRun = sample_info.get('firstRun', -1)
+    #    if firstRun > 0:
+    #        command.append('firstRun=%i' % firstRun)
+    #    lastRun = sample_info.get('lastRun', -1)
+    #    if lastRun > 0:
+    #        command.append('lastRun=%i' % lastRun)
 
     farmout_command = '# Submit file for sample %s\n' % dataset_name
     farmout_command += 'mkdir -p %s\n' % os.path.dirname(dag_dir)

--- a/recipe/environment.sh
+++ b/recipe/environment.sh
@@ -24,8 +24,8 @@ MINOR_VERSION=`echo $CMSSW_VERSION | sed "s|CMSSW_\([0-9]\)_\([0-9]\)_.*|\2|"`
 
 if [ "$MAJOR_VERSION" -eq "7" ]; then
   echo "Setting up CMSSW 7 global tags"
-  export datagt=GR_70_V2_AN1::All
-  export mcgt=MCRUN2_74_V9::All
+  export datagt=GR_P_V56
+  export mcgt=MCRUN2_74_V9
 fi
 
 echo "Data global tag: $datagt"

--- a/recipe/recipe_13TeV.sh
+++ b/recipe/recipe_13TeV.sh
@@ -13,8 +13,6 @@ MINOR_VERSION=`echo $CMSSW_VERSION | sed "s|CMSSW_\([0-9]\)_\([0-9]\)_.*|\2|"`
 
 pushd $CMSSW_BASE/src
 
-#git cms-merge-topic ikrav:egm_id_74X_v2 # mva id
-
 # HZZ MELA, MEKD etc.
 if [ "$HZZ" = "1" ]; then
     echo "Checking out ZZ MELA and Higgs combine"

--- a/recipe/recipe_13TeV.sh
+++ b/recipe/recipe_13TeV.sh
@@ -13,7 +13,7 @@ MINOR_VERSION=`echo $CMSSW_VERSION | sed "s|CMSSW_\([0-9]\)_\([0-9]\)_.*|\2|"`
 
 pushd $CMSSW_BASE/src
 
-git cms-merge-topic ikrav:egm_id_74X_v2 # mva id
+#git cms-merge-topic ikrav:egm_id_74X_v2 # mva id
 
 # HZZ MELA, MEKD etc.
 if [ "$HZZ" = "1" ]; then


### PR DESCRIPTION
The metaInfo tree in FSA ntuples is now filled (correctly, I think!).

The issue was that `edm::EDProducer` and `edm::EDFilter` have been superceded by `edm::one::EDProducer` and `edm::one::EDFilter` (likewise for EDAnalyzer), and the treatment of functions that run at the beginning and end of runs and luminosity blocks changed pretty significantly. I haven't gone through all our code looking for them, but anywhere we use `beginRun(...)`, `endRun(...)`, `beginLuminosityBlock(...)` or `endLuminosityBlock(...)` we need to migrate the calling module over the the appropriate equivalent in the `edm::one::` namespace. Ideally, we should do that for all of our modules. It's not hard, just time consuming (and I don't think it can't be done by a bash one-liner or even a script, though you should feel free to prove me wrong on that).

If we do this the right way, it will also allow us to run multi-threaded, though honestly it's probably not worth the effort to go through all our code and figure out which bits aren't thread-safe.
