### PR TITLE
Add Single Muon Datasets, remove broken PU recipe from meta.rake

### DIFF
--- a/MetaData/tuples/MiniAOD-13TeV_Data.json
+++ b/MetaData/tuples/MiniAOD-13TeV_Data.json
@@ -11,7 +11,6 @@
   "data_Tau_Run2015C_05Oct2015_50ns" : "/Tau/Run2015C_50ns-05Oct2015-v1/MINIAOD",
   "data_SingleMuon_Run2015C_05Oct2015_50ns" : "/SingleMuon/Run2015C_50ns-05Oct2015-v1/MINIAOD",
 
-
   "data_DoubleEG_Run2015C_05Oct2015_25ns" : "/DoubleEG/Run2015C_25ns-05Oct2015-v1/MINIAOD",
   "data_DoubleMuon_Run2015C_05Oct2015_25ns" : "/DoubleMuon/Run2015C_25ns-05Oct2015-v1/MINIAOD",
   "data_MuonEG_Run2015C_05Oct2015_25ns" : "/MuonEG/Run2015C_25ns-05Oct2015-v1/MINIAOD",

--- a/MetaData/tuples/MiniAOD-13TeV_Data.json
+++ b/MetaData/tuples/MiniAOD-13TeV_Data.json
@@ -22,7 +22,11 @@
   "data_DoubleMuon_Run2015D_PromptReco-v4_25ns" : "/DoubleMuon/Run2015D-PromptReco-v4/MINIAOD",
   "data_MuonEG_Run2015D_PromptReco-v4_25ns" : "/MuonEG/Run2015D-PromptReco-v4/MINIAOD",
   "data_DoubleEG_Run2015D_PromptReco-v4_25ns" : "/DoubleEG/Run2015D-PromptReco-v4/MINIAOD",
-  "data_Tau_Run2015D_PromptReco-v4_25ns" : "/Tau/Run2015D-PromptReco-v4/MINIAOD"
+  "data_Tau_Run2015D_PromptReco-v4_25ns" : "/Tau/Run2015D-PromptReco-v4/MINIAOD",
+
+  "data_SingleMuon_Run2015C_PromptReco_25ns" : "/SingleMuon/Run2015C-PromptReco-v1/MINIAOD",
+  "data_SingleMuon_Run2015D_PromptReco-v3_25ns" : "/SingleMuon/Run2015D-PromptReco-v3/MINIAOD",
+  "data_SingleMuon_Run2015D_PromptReco-v4_25ns" : "/SingleMuon/Run2015D-PromptReco-v4/MINIAOD"
 }
 
 

--- a/MetaData/tuples/MiniAOD-13TeV_Data.json
+++ b/MetaData/tuples/MiniAOD-13TeV_Data.json
@@ -3,29 +3,31 @@
   "data_DoubleMuon_Run2015B_23Sep2015_50ns" : "/DoubleMuon/Run2015B-23Sep2015-v1/MINIAOD",
   "data_MuonEG_Run2015B_23Sep2015_50ns" : "/MuonEG/Run2015B-23Sep2015-v1/MINIAOD",
   "data_Tau_Run2015B_23Sep2015_50ns" : "/Tau/Run2015B-23Sep2015-v1/MINIAOD",
+  "data_SingleMuon_Run2015B_23Sep2015_50ns" : "/SingleMuon/Run2015B-23Sep2015-v1/MINIAOD",
 
   "data_DoubleEG_Run2015C_05Oct2015_50ns" : "/DoubleEG/Run2015C_50ns-05Oct2015-v1/MINIAOD",
   "data_DoubleMuon_Run2015C_05Oct2015_50ns" : "/DoubleMuon/Run2015C_50ns-05Oct2015-v1/MINIAOD",
   "data_MuonEG_Run2015C_05Oct2015_50ns" : "/MuonEG/Run2015C_50ns-05Oct2015-v1/MINIAOD",
   "data_Tau_Run2015C_05Oct2015_50ns" : "/Tau/Run2015C_50ns-05Oct2015-v1/MINIAOD",
+  "data_SingleMuon_Run2015C_05Oct2015_50ns" : "/SingleMuon/Run2015C_50ns-05Oct2015-v1/MINIAOD",
+
 
   "data_DoubleEG_Run2015C_05Oct2015_25ns" : "/DoubleEG/Run2015C_25ns-05Oct2015-v1/MINIAOD",
   "data_DoubleMuon_Run2015C_05Oct2015_25ns" : "/DoubleMuon/Run2015C_25ns-05Oct2015-v1/MINIAOD",
   "data_MuonEG_Run2015C_05Oct2015_25ns" : "/MuonEG/Run2015C_25ns-05Oct2015-v1/MINIAOD",
   "data_Tau_Run2015C_05Oct2015_25ns" : "/Tau/Run2015C_25ns-05Oct2015-v1/MINIAOD",
+  "data_SingleMuon_Run2015C_05Oct2015_25ns" : "/SingleMuon/Run2015C_25ns-05Oct2015-v1/MINIAOD",
 
   "data_DoubleMuon_Run2015D_05Oct2015_25ns" : "/DoubleMuon/Run2015D-05Oct2015-v1/MINIAOD",
   "data_MuonEG_Run2015D_05Oct2015_25ns" : "/MuonEG/Run2015D-05Oct2015-v2/MINIAOD",
   "data_DoubleEG_Run2015D_05Oct2015_25ns" : "/DoubleEG/Run2015D-05Oct2015-v1/MINIAOD",
   "data_Tau_Run2015D_05Oct2015_25ns" : "/Tau/Run2015D-05Oct2015-v1/MINIAOD",
+  "data_SingleMuon_Run2015D_05Oct2015_25ns" : "/SingleMuon/Run2015D-05Oct2015-v1/MINIAOD",
 
   "data_DoubleMuon_Run2015D_PromptReco-v4_25ns" : "/DoubleMuon/Run2015D-PromptReco-v4/MINIAOD",
   "data_MuonEG_Run2015D_PromptReco-v4_25ns" : "/MuonEG/Run2015D-PromptReco-v4/MINIAOD",
   "data_DoubleEG_Run2015D_PromptReco-v4_25ns" : "/DoubleEG/Run2015D-PromptReco-v4/MINIAOD",
   "data_Tau_Run2015D_PromptReco-v4_25ns" : "/Tau/Run2015D-PromptReco-v4/MINIAOD",
-
-  "data_SingleMuon_Run2015C_PromptReco_25ns" : "/SingleMuon/Run2015C-PromptReco-v1/MINIAOD",
-  "data_SingleMuon_Run2015D_PromptReco-v3_25ns" : "/SingleMuon/Run2015D-PromptReco-v3/MINIAOD",
   "data_SingleMuon_Run2015D_PromptReco-v4_25ns" : "/SingleMuon/Run2015D-PromptReco-v4/MINIAOD"
 }
 

--- a/PlotTools/rake/meta.rake
+++ b/PlotTools/rake/meta.rake
@@ -50,7 +50,7 @@ namespace :meta do
       # Run lumicalc on the mask
       file sample + '.lumicalc.csv' => sample + '.lumimask.json' do |t|
         #sh "pixelLumiCalc.py overview -i #{t.prerequisites} -o #{t.name}"
-        sh "lumiCalc2.py overview -i #{t.prerequisites} -o #{t.name}"
+        #sh "lumiCalc2.py overview -i #{t.prerequisites} -o #{t.name}"
       end
       # Get the PU distribution
       file sample + '.pu.root' => sample + '.lumimask.json' do |t|
@@ -69,12 +69,12 @@ namespace :meta do
           pu_file = ENV["pu2011JSON"]
         end
         # Find the newest PU json file
-        sh "pileupCalc.py -i #{t.prerequisites[0]} --inputLumiJSON #{pu_file} --calcMode true --minBiasXsec #{minbias} --maxPileupBin #{maxbin} --numPileupBins #{nbins} #{t.name}"
+        #sh "pileupCalc.py -i #{t.prerequisites[0]} --inputLumiJSON #{pu_file} --calcMode true --minBiasXsec #{minbias} --maxPileupBin #{maxbin} --numPileupBins #{nbins} #{t.name}"
       end
       # Put the lumicalc result in a readable format.  Make it dependent
       # on the PU .root file as well, so it gets built.
       file sample + '.lumicalc.sum' => [sample + '.lumicalc.csv', sample + '.pu.root'] do |t|
-        sh "lumicalc_parser.py #{t.prerequisites[0]} > #{t.name}"
+        #sh "lumicalc_parser.py #{t.prerequisites[0]} > #{t.name}"
       end
     else
       # In MC, we can get the effective lumi from xsec and #events.


### PR DESCRIPTION
I've added the SingleMuon datasets to the MiniAOD-13TeV_Data.json file. 

I've also removed the broken PU recipe from meta.rake. I'm not sure if anyone other than me uses the rake stuff, but as you probably know we have to use brilcalc from lxplus to determine the luminosity, not lumiCalc.
