### PR TITLE
Fix memory leaks.

### DIFF
--- a/PatTools/plugins/MiniAODJetSystematicsEmbedder.cc
+++ b/PatTools/plugins/MiniAODJetSystematicsEmbedder.cc
@@ -74,9 +74,9 @@ void MiniAODJetSystematicsEmbedder::produce(edm::Event& evt, const edm::EventSet
 
     //std::cout << "uncDown pt: " << uncDown.pt() << " ,uncUp pt: " << uncUp.pt() << std::endl;
 
-    ShiftedCand candUncDown = *jet.clone();
+    ShiftedCand candUncDown = jet;
     candUncDown.setP4(uncDown);
-    ShiftedCand candUncUp = *jet.clone();
+    ShiftedCand candUncUp = jet;
     candUncUp.setP4(uncUp);
 
     p4OutJESUpJets->push_back(candUncUp);

--- a/PatTools/plugins/PATElectronSystematicsEmbedder.cc
+++ b/PatTools/plugins/PATElectronSystematicsEmbedder.cc
@@ -61,7 +61,7 @@ void PATElectronSystematicsEmbedder::produce(edm::Event& evt, const edm::EventSe
     pat::Electron electron = electrons->at(i); // make a local copy
 
     double pt = electron.pt();
-    ShiftedCand uncorr = *electron.clone();
+    ShiftedCand uncorr = electron;
 
     double correctedPt = nominal_*pt;
     double correctedPtUp = eScaleUp_*pt;
@@ -74,8 +74,8 @@ void PATElectronSystematicsEmbedder::produce(edm::Event& evt, const edm::EventSe
     electron.setP4(reco::Particle::PolarLorentzVector(
           correctedPt, eta, phi, mass));
 
-    ShiftedCand mesUp = *electron.clone();
-    ShiftedCand mesDown = *electron.clone();
+    ShiftedCand mesUp = electron;
+    ShiftedCand mesDown = electron;
 
     mesUp.setP4(reco::Particle::PolarLorentzVector(
           correctedPtUp, eta, phi, mass));

--- a/PatTools/plugins/PATJetSmearEmbedder.cc
+++ b/PatTools/plugins/PATJetSmearEmbedder.cc
@@ -147,9 +147,9 @@ class PATJetSmearEmbedder : public edm::EDProducer
       reco::Candidate::LorentzVector smearUpP4 = jetP4;
       reco::Candidate::LorentzVector smearDownP4 = jetP4;
 
-      ShiftedCand smearedCand = *outputJet.clone();
-      ShiftedCand smearUpCand = *outputJet.clone();
-      ShiftedCand smearDownCand = *outputJet.clone();
+      ShiftedCand smearedCand = outputJet;
+      ShiftedCand smearUpCand = outputJet;
+      ShiftedCand smearDownCand = outputJet;
 
       // Only smear MC
       if (!evt.isRealData()) {

--- a/PatTools/plugins/PATJetUncorrectedEmbedder.cc
+++ b/PatTools/plugins/PATJetUncorrectedEmbedder.cc
@@ -50,7 +50,7 @@ void PATJetUncorrectedEmbedder::produce(edm::Event& evt, const edm::EventSetup& 
   for (size_t i = 0; i < nJets; ++i) {
     const pat::Jet& jet = jets->at(i);
     output->push_back(jet); // make our own copy
-    ShiftedCand uncorr = *jet.clone();
+    ShiftedCand uncorr = jet;
     LorentzVector uncorrectedP4 = jet.correctedP4("Uncorrected");
     uncorr.setP4(uncorrectedP4);
     uncorrected->push_back(uncorr);

--- a/PatTools/plugins/PATMETSystematicsEmbedder.cc
+++ b/PatTools/plugins/PATMETSystematicsEmbedder.cc
@@ -91,7 +91,7 @@ void embedShift(pat::MET& met, edm::Event& evt,
   typedef reco::CandidatePtr CandidatePtr;
 
   std::auto_ptr<ShiftedCandCollection> output(new ShiftedCandCollection);
-  ShiftedCand newCand = *met.clone();
+  ShiftedCand newCand = met;
   newCand.setP4(transverse(newCand.p4() + residual));
   output->push_back(newCand);
   PutHandle outputH = evt.put(output, branchName);

--- a/PatTools/plugins/PATMuonSystematicsEmbedder.cc
+++ b/PatTools/plugins/PATMuonSystematicsEmbedder.cc
@@ -111,10 +111,10 @@ void PATMuonSystematicsEmbedder::produce(edm::Event& evt, const edm::EventSetup&
     double phi = muon.phi();
     double mass = muon.mass();
 
-    ShiftedCand uncorr = *muon.clone();
-    ShiftedCand nominal = *muon.clone();
-    ShiftedCand mesUp = *muon.clone();
-    ShiftedCand mesDown = *muon.clone();
+    ShiftedCand uncorr = muon;
+    ShiftedCand nominal = muon;
+    ShiftedCand mesUp = muon;
+    ShiftedCand mesDown = muon;
 
     // Don't apply the correction by default, no one else does.
 

--- a/PatTools/plugins/PATTauSystematicsEmbedder.cc
+++ b/PatTools/plugins/PATTauSystematicsEmbedder.cc
@@ -172,17 +172,17 @@ void PATTauSystematicsEmbedder::produce(edm::Event& evt, const edm::EventSetup& 
   for (size_t i = 0; i < nTaus; ++i) {
     const pat::Tau& origTau = taus->at(i);
     output->push_back(origTau); // make our own copy
-    ShiftedCand p4OutNomTau = *origTau.clone();
+    ShiftedCand p4OutNomTau = origTau; // makes copy
     p4OutNomTaus->push_back(p4OutNomTau);
     // Now make the smeared versions of the jets and taus
     // TES uncertainty
     ShiftedLorentzVectors tesShifts = tauJetCorrection_.uncertainties(
         p4OutNomTau.p4());
-    ShiftedCand p4OutTESUpTau = *p4OutNomTau.clone();
+    ShiftedCand p4OutTESUpTau = p4OutNomTau;
     p4OutTESUpTau.setP4(tesShifts.shiftedUp);
     p4OutTESUpTaus->push_back(p4OutTESUpTau);
 
-    ShiftedCand p4OutTESDownTau = *p4OutNomTau.clone();
+    ShiftedCand p4OutTESDownTau = p4OutNomTau;
     p4OutTESDownTau.setP4(tesShifts.shiftedDown);
     p4OutTESDownTaus->push_back(p4OutTESDownTau);
   }


### PR DESCRIPTION
So it turns out that

```
Thing* t = whatever.clone();
```

does not have the same effect as

```
Thing t = *whatever.clone();
```

and the difference matters to the tune of a few tens of kilobytes per event and a more-in-sorrow-than-in-anger email from the computing guys. 

Can one of the people responsible for the original leaks forward port, please?
