### PR TITLE
Option to skip MET corrections

### DIFF
--- a/NtupleTools/python/customization_hzz.py
+++ b/NtupleTools/python/customization_hzz.py
@@ -95,12 +95,15 @@ def hzzCustomize(process, fs_daughter_inputs,
         fsrLabel = cms.string(fsrLabel),
         fsrElecSelection = cms.string('userFloat("%s") > 0.5'%idCheatLabel),
         fsrMuonSelection = cms.string('userFloat("%s") > 0.5'%idCheatLabel),
-        eaLabel = cms.string('EffectiveArea_HZZ4l2015'),
-        #eaScaleFactor = cms.double(16./9.), # until we get effective areas for a cone of 0.4
+        eaLabel = cms.string('EffectiveArea'),
+        isoConeDRMaxE = cms.double(0.3),
+        isoConeDRMaxMu = cms.double(0.3),
+        isoCutE = cms.double(0.35),
+        isoCutMu = cms.double(0.35),
         )
 
-    fs_daughter_inputs['electrons'] = 'leptonIsoCheatEmbedding'
-    fs_daughter_inputs['muons'] = 'leptonIsoCheatEmbedding'
+    fs_daughter_inputs['electrons'] = 'leptonIsoCheatEmbedding:electrons'
+    fs_daughter_inputs['muons'] = 'leptonIsoCheatEmbedding:muons'
     
     process.embedHZZ4lIsoDecisions = cms.Path(
         process.leptonIsoCheatEmbedding

--- a/NtupleTools/python/parameters/zz.py
+++ b/NtupleTools/python/parameters/zz.py
@@ -28,34 +28,21 @@ for fsrVar in ['pt', 'eta', 'phi']:
     setattr(zzEvVars, '%s%s'%(varCap, brSuffix),
             cms.string('p4WithUserCands("%sCand").%s'%(fsr, varCap)))
 
-setattr(eleVars, "objectRelPFIsoRho%s"%brSuffix,
-        cms.string(('({object}.chargedHadronIso()' +
-                    '+max(0.0,{object}.neutralHadronIso()' +
-                    '+{object}.photonIso()' +
-                    '-daughterUserCandIsoContribution({object_idx}, "%sCand")' +
-                    '-{object}.userFloat("rho_fastjet")*{object}.userFloat("EffectiveArea_HZZ4l2015")))' +
-                    '/{object}.pt()')%(fsr))
+setattr(eleVars, "objectRelPFIsoRhoR03",
+        cms.string('({object}.pfIsolationVariables().sumChargedHadronPt' +
+                   '+max(0.0,{object}.pfIsolationVariables().sumNeutralHadronEt' +
+                   '+{object}.pfIsolationVariables().sumPhotonEt' +
+                   '-{object}.userFloat("rho_fastjet")*{object}.userFloat("EffectiveArea")))' +
+                   '/{object}.pt()')
         ),
 
-setattr(eleVars, "objectRelPFIsoRho%s_unscaled"%brSuffix,
-        cms.string(('({object}.chargedHadronIso()' +
-                    '+max(0.0,{object}.neutralHadronIso()' +
-                    '+{object}.photonIso()' +
-                    '-daughterUserCandIsoContribution({object_idx}, "%sCand")' +
-                    '-{object}.userFloat("rho_fastjet")*{object}.userFloat("EffectiveArea")*16./9.))' +
-                    '/{object}.pt()')%(fsr))
-        ),
-
-setattr(muVars, "objectRelPFIsoDB%s"%brSuffix,
-        cms.string(('({object}.chargedHadronIso()' +
-                    '+max({object}.photonIso()' +
-                    '-daughterUserCandIsoContribution({object_idx}, "%sCand")' +
-                    '+{object}.neutralHadronIso()' +
-                    '-0.5*{object}.puChargedHadronIso,0.0))' +
-                    '/{object}.pt()')%(fsr))
+setattr(muVars, "objectRelPFIsoDBR03",
+        cms.string('({object}.pfIsolationR03().sumChargedParticlePt' +
+                   '+max({object}.pfIsolationR03().sumPhotonEt' +
+                   '+{object}.pfIsolationR03().sumNeutralHadronEt' +
+                   '-0.5*{object}.pfIsolationR03().sumPUPt,0.0))' +
+                   '/{object}.pt()')
         )
-
-eleVars.objectEffectiveAreaHZZ = cms.string('{object}.userFloat("EffectiveArea_HZZ4l2015")')
 
 zzObjVars.objectHZZIsoFSR = cms.string('? {object}.hasUserFloat("HZZ4lIsoVal") ? {object}.userFloat("HZZ4lIsoVal") : 999.')
 
@@ -87,7 +74,7 @@ parameters = {
         [
             # vertex cuts
             #('v', '!isFake && ndof > 4 && abs(z) <= 24 && position.Rho <= 2'),
-            ('m', ''),
+
             # Veto electrons that are very close to muons
             ('e', {
                     'm' : {

--- a/NtupleTools/test/make_ntuples_cfg.py
+++ b/NtupleTools/test/make_ntuples_cfg.py
@@ -50,6 +50,8 @@ nExtraJets=0   - Include basic info about this many jets (ordered by pt).
 paramFile=''   - custom parameter file for ntuple production
 keepPat=0      - Instead of making flat ntuples, write high level 
                  physics objects including the PATFinalState objects
+skipMET=0      - Don't do MET corrections and systematics (good way to reduce 
+                 memory use if you don't use them)
 
 '''
 
@@ -68,8 +70,8 @@ process = cms.Process("Ntuples")
 # if you want to debug in the future, uncomment this
 #process.ProfilerService = cms.Service (
 #      "ProfilerService",
-#       firstEvent = cms.untracked.int32(1),
-#       lastEvent = cms.untracked.int32(100),
+#       firstEvent = cms.untracked.int32(2),
+#       lastEvent = cms.untracked.int32(500),
 #       paths = cms.untracked.vstring('schedule') 
 #)
 #
@@ -77,6 +79,7 @@ process = cms.Process("Ntuples")
 #    "SimpleMemoryCheck",
 #    ignoreTotal = cms.untracked.int32(1)
 #)
+
 
 process.options = cms.untracked.PSet(
     allowUnscheduled = cms.untracked.bool(True),
@@ -156,6 +159,14 @@ options.register(
     'Apply electron energy correction as a 1-sigma shift instead of a '
     'smearing. Only used if eCalib=0 and isMC=1.'
 )
+options.register(
+    'skipMET',
+    0,
+    TauVarParsing.TauVarParsing.multiplicity.singleton,
+    TauVarParsing.TauVarParsing.varType.int,
+    "Skip MET corrections and systematics (good way to reduce memory "
+    "use if you don't need them)."
+)
 
 options.outputFile = "ntuplize.root"
 options.parseArguments()
@@ -223,6 +234,24 @@ process.maxEvents = cms.untracked.PSet(
     input=cms.untracked.int32(options.maxEvents))
 
 process.schedule = cms.Schedule()
+
+### To use IgProf's neat memory profiling tools, uncomment the following 
+### lines then run this cfg with igprof like so:
+###      $ igprof -d -mp -z -o igprof.mp.gz cmsRun ... 
+### this will create a memory profile every 250 events so you can track use
+### Turn the profile into text with
+###      $ igprof-analyse -d -v -g -r MEM_LIVE igprof.yourOutputFile.gz > igreport_live.res
+### To do a performance profile instead of a memory profile, change -mp to -pp
+### in the first command and remove  -r MEM_LIVE from the second
+### For interpretation of the output, see http://igprof.org/text-output-format.html
+
+#from IgTools.IgProf.IgProfTrigger import igprof
+#process.load("IgTools.IgProf.IgProfTrigger")
+#process.igprofPath = cms.Path(process.igprof)
+#process.igprof.reportEventInterval     = cms.untracked.int32(250)
+#process.igprof.reportToFileAtBeginJob  = cms.untracked.string("|gzip -c>igprof.begin-job.gz")
+#process.igprof.reportToFileAtEvent = cms.untracked.string("|gzip -c>igprof.%I.%E.%L.%R.event.gz")
+#process.schedule.append(process.igprofPath)
 
 #load magfield and geometry (for mass resolution)
 process.load('Configuration.Geometry.GeometryRecoDB_cff')
@@ -417,124 +446,125 @@ if abs(options.runFSRFilter)>0:
 ### MET Uncertainty and Corrections ###
 #######################################
 
-postfix = 'NewMet'
-from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
-isData = not options.isMC
-runMetCorAndUncFromMiniAOD(process,
-                           jetColl=fs_daughter_inputs['jets'],
-                           jetCollUnskimmed='slimmedJets',
-                           photonColl=fs_daughter_inputs['photons'],
-                           electronColl=fs_daughter_inputs['electrons'],
-                           muonColl=fs_daughter_inputs['muons'],
-                           tauColl=fs_daughter_inputs['taus'],
-                           isData=isData,
-                           jecUncFile='FinalStateAnalysis/NtupleTools/data/Summer15_25nsV6_{0}_UncertaintySources_AK4PFchs.txt'.format('MC' if options.isMC else 'DATA'),
-                           repro74X=True,
-                           postfix=postfix,
-                           )
-
-collMap = {
-    #'jres' : {'Jets'     : 'shiftedPatJetRes{sign}{postfix}'},
-    'jres' : {},
-    'jes'  : {'Jets'     : 'shiftedPatJetEn{sign}{postfix}'},
-    'mes'  : {'Muons'    : 'shiftedPatMuonEn{sign}{postfix}'},
-    'ees'  : {'Electrons': 'shiftedPatElectronEn{sign}{postfix}'},
-    'tes'  : {'Taus'     : 'shiftedPatTauEn{sign}{postfix}'},
-    'ues'  : {},
-    'pes'  : {},
-}
-signMap = {
-  '+' : 'Up',
-  '-' : 'Down',
-}
-metMap = {
-  'jres' : 'patPFMetT1JetRes{sign}{postfix}',
-  'jes'  : 'patPFMetT1JetEn{sign}{postfix}',
-  'mes'  : 'patPFMetT1MuonEn{sign}{postfix}',
-  'ees'  : 'patPFMetT1ElectronEn{sign}{postfix}',
-  'tes'  : 'patPFMetT1TauEn{sign}{postfix}',
-  'ues'  : 'patPFMetT1UnclusteredEn{sign}{postfix}',
-  'pes'  : '',
-}
-allowedShifts = ['jres','jes','mes','ees','tes','ues']
-allowedSigns = ['+','-']
-
-# this should be it, but fails
-#process.applyCorrections = cms.Path(getattr(process,'fullPatMetSequence{0}'.format(postfix)))
-# fix things
-getattr(process,'patPFMetT1T2Corr{0}'.format(postfix)).src = cms.InputTag('patJets')
-getattr(process,'patPFMetT2Corr{0}'.format(postfix)).src = cms.InputTag('patJets')
-getattr(process,'patPFMetTxyCorr{0}'.format(postfix)).vertexCollection = cms.InputTag('offlineSlimmedPrimaryVertices')
-process.applyCorrections = cms.Path()
-if options.isMC: process.applyCorrections += process.genMetExtractor
-process.applyCorrections += getattr(process,'patPFMet{0}'.format(postfix))
-process.applyCorrections += process.patJetCorrFactorsReapplyJEC
-process.applyCorrections += process.patJets
-process.applyCorrections += getattr(process,'patPFMetT1Txy{0}'.format(postfix))
-process.applyCorrections += getattr(process,'patPFMetT1{0}'.format(postfix))
-process.applyCorrections += getattr(process,'patPFMetTxy{0}'.format(postfix))
-process.schedule.append(process.applyCorrections)
-fs_daughter_inputs['jets'] = 'patJets'
-
-# embed references to shifts
-process.embedShifts = cms.Path()
-for shift in allowedShifts:
-    for sign in allowedSigns:
-        # embed shifted objects
-        for coll in collMap[shift]:
-            modName = '{shift}{sign}{coll}Embedding'.format(shift=shift,sign=signMap[sign],coll=coll)
-            pluginName = 'MiniAODShifted{coll}Embedder'.format(coll=coll[:-1])
-            dName = coll.lower()
-            srcName = fs_daughter_inputs[dName]
-            shiftSrcName = collMap[shift][coll].format(sign=signMap[sign],postfix=postfix)
-            label = '{shift}{sign}{coll}'.format(shift=shift,sign=signMap[sign],coll=coll)
+if not bool(options.skipMET):
+    postfix = 'NewMet'
+    from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
+    isData = not options.isMC
+    runMetCorAndUncFromMiniAOD(process,
+                               jetColl=fs_daughter_inputs['jets'],
+                               jetCollUnskimmed='slimmedJets',
+                               photonColl=fs_daughter_inputs['photons'],
+                               electronColl=fs_daughter_inputs['electrons'],
+                               muonColl=fs_daughter_inputs['muons'],
+                               tauColl=fs_daughter_inputs['taus'],
+                               isData=isData,
+                               jecUncFile='FinalStateAnalysis/NtupleTools/data/Summer15_25nsV6_{0}_UncertaintySources_AK4PFchs.txt'.format('MC' if options.isMC else 'DATA'),
+                               repro74X=True,
+                               postfix=postfix,
+                               )
+    
+    collMap = {
+        #'jres' : {'Jets'     : 'shiftedPatJetRes{sign}{postfix}'},
+        'jres' : {},
+        'jes'  : {'Jets'     : 'shiftedPatJetEn{sign}{postfix}'},
+        'mes'  : {'Muons'    : 'shiftedPatMuonEn{sign}{postfix}'},
+        'ees'  : {'Electrons': 'shiftedPatElectronEn{sign}{postfix}'},
+        'tes'  : {'Taus'     : 'shiftedPatTauEn{sign}{postfix}'},
+        'ues'  : {},
+        'pes'  : {},
+    }
+    signMap = {
+      '+' : 'Up',
+      '-' : 'Down',
+    }
+    metMap = {
+      'jres' : 'patPFMetT1JetRes{sign}{postfix}',
+      'jes'  : 'patPFMetT1JetEn{sign}{postfix}',
+      'mes'  : 'patPFMetT1MuonEn{sign}{postfix}',
+      'ees'  : 'patPFMetT1ElectronEn{sign}{postfix}',
+      'tes'  : 'patPFMetT1TauEn{sign}{postfix}',
+      'ues'  : 'patPFMetT1UnclusteredEn{sign}{postfix}',
+      'pes'  : '',
+    }
+    allowedShifts = ['jres','jes','mes','ees','tes','ues']
+    allowedSigns = ['+','-']
+    
+    # this should be it, but fails
+    #process.applyCorrections = cms.Path(getattr(process,'fullPatMetSequence{0}'.format(postfix)))
+    # fix things
+    getattr(process,'patPFMetT1T2Corr{0}'.format(postfix)).src = cms.InputTag('patJets')
+    getattr(process,'patPFMetT2Corr{0}'.format(postfix)).src = cms.InputTag('patJets')
+    getattr(process,'patPFMetTxyCorr{0}'.format(postfix)).vertexCollection = cms.InputTag('offlineSlimmedPrimaryVertices')
+    process.applyCorrections = cms.Path()
+    if options.isMC: process.applyCorrections += process.genMetExtractor
+    process.applyCorrections += getattr(process,'patPFMet{0}'.format(postfix))
+    process.applyCorrections += process.patJetCorrFactorsReapplyJEC
+    process.applyCorrections += process.patJets
+    process.applyCorrections += getattr(process,'patPFMetT1Txy{0}'.format(postfix))
+    process.applyCorrections += getattr(process,'patPFMetT1{0}'.format(postfix))
+    process.applyCorrections += getattr(process,'patPFMetTxy{0}'.format(postfix))
+    process.schedule.append(process.applyCorrections)
+    fs_daughter_inputs['jets'] = 'patJets'
+    
+    # embed references to shifts
+    process.embedShifts = cms.Path()
+    for shift in allowedShifts:
+        for sign in allowedSigns:
+            # embed shifted objects
+            for coll in collMap[shift]:
+                modName = '{shift}{sign}{coll}Embedding'.format(shift=shift,sign=signMap[sign],coll=coll)
+                pluginName = 'MiniAODShifted{coll}Embedder'.format(coll=coll[:-1])
+                dName = coll.lower()
+                srcName = fs_daughter_inputs[dName]
+                shiftSrcName = collMap[shift][coll].format(sign=signMap[sign],postfix=postfix)
+                label = '{shift}{sign}{coll}'.format(shift=shift,sign=signMap[sign],coll=coll)
+                module = cms.EDProducer(
+                    pluginName,
+                    src = cms.InputTag(srcName),
+                    shiftSrc = cms.InputTag(shiftSrcName),
+                    label = cms.string(label),
+                )
+                setattr(process,modName,module)
+                fs_daughter_inputs[dName] = modName
+                #process.embedShifts *= getattr(process,shiftSrcName)
+                process.embedShifts *= getattr(process,modName)
+            # embed shifted met
+            modName = '{shift}{sign}METEmbedding'.format(shift=shift,sign=signMap[sign])
+            metName = metMap[shift].format(sign=signMap[sign],postfix=postfix)
+            label = '{shift}{sign}MET'.format(shift=shift,sign=signMap[sign])
             module = cms.EDProducer(
-                pluginName,
-                src = cms.InputTag(srcName),
-                shiftSrc = cms.InputTag(shiftSrcName),
+                'MiniAODShiftedMETEmbedder',
+                src = cms.InputTag(fs_daughter_inputs['pfmet']),
+                shiftSrc = cms.InputTag(metName),
                 label = cms.string(label),
             )
             setattr(process,modName,module)
-            fs_daughter_inputs[dName] = modName
-            #process.embedShifts *= getattr(process,shiftSrcName)
+            fs_daughter_inputs['pfmet'] = modName
             process.embedShifts *= getattr(process,modName)
-        # embed shifted met
-        modName = '{shift}{sign}METEmbedding'.format(shift=shift,sign=signMap[sign])
-        metName = metMap[shift].format(sign=signMap[sign],postfix=postfix)
-        label = '{shift}{sign}MET'.format(shift=shift,sign=signMap[sign])
-        module = cms.EDProducer(
-            'MiniAODShiftedMETEmbedder',
-            src = cms.InputTag(fs_daughter_inputs['pfmet']),
-            shiftSrc = cms.InputTag(metName),
-            label = cms.string(label),
-        )
-        setattr(process,modName,module)
-        fs_daughter_inputs['pfmet'] = modName
-        process.embedShifts *= getattr(process,modName)
-process.schedule.append(process.embedShifts)
-
-
-# switch input to desired one
-if options.metShift: 
-    t = options.metShift[:-1]
-    d = options.metShift[-1]
-    if options.metShift=='all':
-        # setup daughters for all
-        for shift in allowedShifts:
-            if shift!='mes': continue
-            for sign in allowedSigns:
-                if sign!='+': continue
-                label = shift + signMap[sign]
-                additional_fs[label] = copy.deepcopy(fs_daughter_inputs)
-                additional_fs[label]['pfmet'] = metMap[shift].format(sign=signMap[sign],postfix=postfix)
-                for coll in collMap[shift]:
-                    additional_fs[label][coll.lower()] = collMap[shift][coll].format(sign=signMap[sign],postfix=postfix)
-    elif t not in allowedShifts or d not in allowedSigns:
-        print 'Warning: {0} is not an allowed MET shift, using unshifted collections'.format(options.metShift)
-    else:
-        fs_daughter_inputs['pfmet'] = metMap[t].format(sign=signMap[d],postfix=postfix)
-        for coll in collMap[t]:
-            fs_daughter_inputs[coll.lower()] = collMap[t][coll].format(sign=signMap[d],postfix=postfix)
+    process.schedule.append(process.embedShifts)
+    
+    
+    # switch input to desired one
+    if options.metShift: 
+        t = options.metShift[:-1]
+        d = options.metShift[-1]
+        if options.metShift=='all':
+            # setup daughters for all
+            for shift in allowedShifts:
+                if shift!='mes': continue
+                for sign in allowedSigns:
+                    if sign!='+': continue
+                    label = shift + signMap[sign]
+                    additional_fs[label] = copy.deepcopy(fs_daughter_inputs)
+                    additional_fs[label]['pfmet'] = metMap[shift].format(sign=signMap[sign],postfix=postfix)
+                    for coll in collMap[shift]:
+                        additional_fs[label][coll.lower()] = collMap[shift][coll].format(sign=signMap[sign],postfix=postfix)
+        elif t not in allowedShifts or d not in allowedSigns:
+            print 'Warning: {0} is not an allowed MET shift, using unshifted collections'.format(options.metShift)
+        else:
+            fs_daughter_inputs['pfmet'] = metMap[t].format(sign=signMap[d],postfix=postfix)
+            for coll in collMap[t]:
+                fs_daughter_inputs[coll.lower()] = collMap[t][coll].format(sign=signMap[d],postfix=postfix)
 
 
 


### PR DESCRIPTION
They are pretty memory-heavy. @dntaylor, should I forward-port this to 76X now or wait until MET stuff is all working there?

Also adds instructions and sample code for some neat profiling tools, and changes ZZ isolation.
