### PR TITLE
few modification for LFVH in 76X

### DIFF
--- a/MetaData/python/data13TeV_LFV.py
+++ b/MetaData/python/data13TeV_LFV.py
@@ -101,6 +101,73 @@ datadefs["DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8"] = {
     'calibrationTarget': 'RunIISpring15DR7',
     'x_sec': 18610.0 ,
 }
+###new stuff
+datadefs["DY1JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8"] = {
+    'analyses': ['4L'],
+    'datasetpath': '/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM',
+    'pu': 'Asympt25ns',
+    'calibrationTarget': 'RunIISpring15DR7',
+    'x_sec': 1016 ,
+}
+
+datadefs["DY2JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8"] = {
+    'analyses': ['4L'],
+    'datasetpath': '/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM',
+    'pu': 'Asympt25ns',
+    'calibrationTarget': 'RunIISpring15DR7',
+    'x_sec': 331.4 ,
+}
+
+datadefs["DY3JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8"] = {
+    'analyses': ['4L'],
+    'datasetpath': '/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM',
+    'pu': 'Asympt25ns',
+    'calibrationTarget': 'RunIISpring15DR7',
+    'x_sec':96.36 ,
+}
+
+
+datadefs["DY4JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8"] = {
+    'analyses': ['4L'],
+    'datasetpath': '/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM',
+    'pu': 'Asympt25ns',
+    'calibrationTarget': 'RunIISpring15DR7',
+    'x_sec': 51.40 ,
+}
+
+datadefs["DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8"] = {
+    'analyses': ['4L'],
+    'datasetpath': '/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM',
+    'pu': 'Asympt25ns',
+    'calibrationTarget': 'RunIISpring15DR7',
+    'x_sec': 147.40 ,
+}
+
+datadefs["DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8"] = {
+    'analyses': ['4L'],
+    'datasetpath': '/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM',
+    'pu': 'Asympt25ns',
+    'calibrationTarget': 'RunIISpring15DR7',
+    'x_sec': 40.99 ,
+}
+
+datadefs["DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8"] = {
+    'analyses': ['4L'],
+    'datasetpath': '/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM',
+    'pu': 'Asympt25ns',
+    'calibrationTarget': 'RunIISpring15DR7',
+    'x_sec': 5.678 ,
+}
+
+
+datadefs["DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8"] = {
+    'analyses': ['4L'],
+    'datasetpath': '/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM',
+    'pu': 'Asympt25ns',
+    'calibrationTarget': 'RunIISpring15DR7',
+    'x_sec': 2.198 ,
+}
+
 datadefs["ZZ_TuneCUETP8M1_13TeV-pythia8"] = {
     'analyses': ['4L'],
     'datasetpath': '/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM',

--- a/MetaData/python/data_views.py
+++ b/MetaData/python/data_views.py
@@ -35,7 +35,7 @@ def read_lumi(filename):
         try:
             #print lumifile.readline().strip()
             lumistr=lumifile.readline().strip()
-            print lumistr, filename
+            print 'lumi and file', lumifile.readline().strip(), lumistr, filename
             return float(lumistr)
         except ValueError:
             print "I couldn't extract a float from %s" % filename

--- a/PlotTools/python/Plotter.py
+++ b/PlotTools/python/Plotter.py
@@ -39,7 +39,7 @@ class Plotter(object):
         self.views = data_views(files, lumifiles, forceLumi)
         self.canvas = plotting.Canvas(name='adsf', title='asdf')
         self.canvas.cd()
-        self.pad    = plotting.Pad('up', 'up', 0., 0., 1., 1.) #ful-size pad
+        self.pad    = plotting.Pad(0., 0., 1., 1.) #ful-size pad
         self.pad.Draw()
         self.pad.cd()
         self.lower_pad = None
@@ -180,7 +180,7 @@ class Plotter(object):
         self.pad.Draw()
         self.canvas.cd()
         #create lower pad
-        self.lower_pad = plotting.Pad('low', 'low', 0, 0., 1., 0.33)
+        self.lower_pad = plotting.Pad( 0, 0., 1., 0.33)
         self.lower_pad.Draw()
         self.lower_pad.cd()
         
@@ -269,7 +269,7 @@ class Plotter(object):
         self.keep = []
         self.canvas = plotting.Canvas(name='adsf', title='asdf')
         self.canvas.cd()
-        self.pad    = plotting.Pad('up', 'up', 0., 0., 1., 1.) #ful-size pad
+        self.pad    = plotting.Pad( 0., 0., 1., 1.) #ful-size pad
         self.pad.Draw()
         self.pad.cd()
         self.lower_pad = None

--- a/TagAndProbe/python/MuonPOGCorrections.py
+++ b/TagAndProbe/python/MuonPOGCorrections.py
@@ -398,6 +398,7 @@ class MuonPOGCorrection2D(object):
 
     def __call__(self, pt, eta):
         if pt >= 120: pt = 115.
+        if pt < 20. : pt = 20.
         key = self.file.Get(self.histopath)
         self.correct_by_pt_abseta =key.GetBinContent(key.FindFixBin(pt, eta))
         #print 'Mu ID/Tr correction :', pt, eta,  self.correct_by_pt_abseta
@@ -415,6 +416,7 @@ class MuonPOGCorrectionIso2D(object):
  
     def __call__(self, mid, pt, eta):
         if pt >= 120: pt = 115.
+        if pt < 20. : pt = 20.
         if mid == 'Tight':
              key = self.file.Get(self.histopathTIGHT)
              self.correct_by_pt_abseta =key.GetBinContent(key.FindFixBin(pt, eta))


### PR DESCRIPTION
Adding dataset info in data13TeV_LFV.py, DYJets in data_views. 
Changing Plotter.py according to the new version of roopy.
Make the muon correction for muon with pt < 20 GeV, the same as for muon with pt >20 instead of having 0 (no muon with pt< 20 will be included in the lfv analysis)
