### PR TITLE
adding/updating 76X muon corrections(from 74)

### DIFF
--- a/TagAndProbe/python/MuonPOGCorrections.py
+++ b/TagAndProbe/python/MuonPOGCorrections.py
@@ -55,9 +55,9 @@ _DATA_FILES = {
     '2012C'    : os.path.join(_DATA_DIR, 'MuonEfficiencies_Run_2012C_53X.root'),
     '2012D'    : os.path.join(_DATA_DIR, 'TriggerMuonEfficiencies_Run_2012D_53X.root'),
     '2015CD' : {
-        'PFID'   : os.path.join(_DATA_DIR, 'MuonID_Z_RunCD_Reco74X_Dec1.root'),
-        'Iso'    : os.path.join(_DATA_DIR, 'MuonIso_Z_RunCD_Reco74X_Dec1.root'),
-        'Trigger': os.path.join(_DATA_DIR, 'SingleMuonTrigger_Z_RunCD_Reco74X_Dec1.root')
+        'PFID'   : os.path.join(_DATA_DIR, 'MuonID_Z_RunCD_Reco76X_Feb15.root'),
+        'Iso'    : os.path.join(_DATA_DIR, 'MuonIso_Z_RunCD_Reco76X_Feb15.root'),
+        'Trigger': os.path.join(_DATA_DIR, 'SingleMuonTrigger_Z_RunCD_Reco76X_Feb15.root')
     }
 }
 
@@ -109,40 +109,40 @@ def make_muon_pog_PFTight_2015CD():
     ''' Make PFTight DATA/MC corrector for 2012 '''
     return MuonPOGCorrection2D(
         _DATA_FILES['2015CD']['PFID'],
-        "NUM_TightIDandIPCut_DEN_genTracks_PAR_pt_spliteta_bin1/pt_abseta_ratio"
+        "MC_NUM_TightIDandIPCut_DEN_genTracks_PAR_pt_spliteta_bin1/pt_abseta_ratio"
     )
 def make_muon_pog_PFMedium_2015CD():
     ''' Make PFTight DATA/MC corrector for 2012 '''
     return MuonPOGCorrection2D(
         _DATA_FILES['2015CD']['PFID'],
-        "NUM_MediumID_DEN_genTracks_PAR_pt_spliteta_bin1/pt_abseta_ratio"
+        "MC_NUM_MediumID_DEN_genTracks_PAR_pt_spliteta_bin1/pt_abseta_ratio"
     )
 def make_muon_pog_PFLoose_2015CD():
     return MuonPOGCorrection2D(
         _DATA_FILES['2015CD']['PFID'],
-        "NUM_LooseID_DEN_genTracks_PAR_pt_spliteta_bin1/pt_abseta_ratio"
+        "MC_NUM_LooseID_DEN_genTracks_PAR_pt_spliteta_bin1/pt_abseta_ratio"
     )
 
 def make_muon_pog_LooseIso_2015CD():
     return MuonPOGCorrectionIso2D(
         _DATA_FILES['2015CD']['Iso'],
-        "NUM_LooseRelIso_DEN_LooseID_PAR_pt_spliteta_bin1/pt_abseta_ratio",
-        "NUM_LooseRelIso_DEN_MediumID_PAR_pt_spliteta_bin1/pt_abseta_ratio",
-        "NUM_LooseRelIso_DEN_TightID_PAR_pt_spliteta_bin1/pt_abseta_ratio",
+        "MC_NUM_LooseRelIso_DEN_LooseID_PAR_pt_spliteta_bin1/pt_abseta_ratio",
+        "MC_NUM_LooseRelIso_DEN_MediumID_PAR_pt_spliteta_bin1/pt_abseta_ratio",
+        "MC_NUM_LooseRelIso_DEN_TightID_PAR_pt_spliteta_bin1/pt_abseta_ratio",
     )
 def make_muon_pog_MediumIso_2015CD():
     return MuonPOGCorrectionIso2D(
         _DATA_FILES['2015CD']['Iso'],
-        "NUM_MediumRelIso_DEN_LooseID_PAR_pt_spliteta_bin1/pt_abseta_ratio",
-        "NUM_MediumRelIso_DEN_MediumID_PAR_pt_spliteta_bin1/pt_abseta_ratio",
-        "NUM_MediumRelIso_DEN_TightID_PAR_pt_spliteta_bin1/pt_abseta_ratio",
+        "MC_NUM_MediumRelIso_DEN_LooseID_PAR_pt_spliteta_bin1/pt_abseta_ratio",
+        "MC_NUM_MediumRelIso_DEN_MediumID_PAR_pt_spliteta_bin1/pt_abseta_ratio",
+        "MC_NUM_MediumRelIso_DEN_TightID_PAR_pt_spliteta_bin1/pt_abseta_ratio",
     )
 def make_muon_pog_TightIso_2015CD():
     return MuonPOGCorrectionIso2D(
         _DATA_FILES['2015CD']['Iso'],
-        "NUM_TightRelIso_DEN_LooseID_PAR_pt_spliteta_bin1/pt_abseta_ratio",
-        "NUM_TightRelIso_DEN_MediumID_PAR_pt_spliteta_bin1/pt_abseta_ratio",
-        "NUM_TightRelIso_DEN_TightID_PAR_pt_spliteta_bin1/pt_abseta_ratio",
+        "MC_NUM_TightRelIso_DEN_LooseID_PAR_pt_spliteta_bin1/pt_abseta_ratio",
+        "MC_NUM_TightRelIso_DEN_MediumID_PAR_pt_spliteta_bin1/pt_abseta_ratio",
+        "MC_NUM_TightRelIso_DEN_TightID_PAR_pt_spliteta_bin1/pt_abseta_ratio",
     )
 
 def make_muon_pog_PFRelIsoDB012_2012():


### PR DESCRIPTION
Muon corrections for 76X became recently available:

https://twiki.cern.ch/twiki/bin/viewauth/CMS/MuonReferenceEffsRun2#Results_for_CMSSW_7_6_X_dataset

Updating from the 74X correction files to 76X.
