### PR TITLE
Only build PATFinalState objects for ntuplized channels

### DIFF
--- a/NtupleTools/python/channel_handling.py
+++ b/NtupleTools/python/channel_handling.py
@@ -1,0 +1,109 @@
+#############################################################################
+#                                                                           #
+#   channel_handling.py                                                     #
+#                                                                           #
+#   Some functions to handle the various decay channels, the groups they    #
+#   inhabit, and the objects in them.                                       #
+#                                                                           #
+#   Nate Woods, U. Wisconsin                                                #
+#                                                                           #
+#############################################################################
+
+
+
+_FINAL_STATE_GROUPS = {
+    'zh': ['eeem', 'eeet', 'eemt', 'eett', 'emmm', 'emmt', 'mmmt', 'mmtt'],
+    'zz': ['eeee', 'eemm', 'mmmm'],
+    'zgg': ['eegg', 'mmgg'],
+    'llt': ['emt', 'mmt', 'eet', 'mmm', 'emm', 'mm', 'ee', 'em'],
+    'zg': ['mmg', 'eeg'],
+    'zgxtra': ['mgg', 'emg', 'egg'],
+    'dqm': ['e', 'm', 't', 'g', 'j'],
+    '3lep': ['eee', 'eem', 'eet', 'emm', 'emt', 'ett', 
+             'mmm', 'mmt', 'mtt', 'ttt'],
+    '4lep': ['eeee', 'eeem', 'eeet', 'eemm', 'eemt', 'eett', 'emmm', 
+             'emmt', 'emtt', 'ettt', 'mmmm', 'mmmt', 'mmtt', 'mttt', 'tttt'],
+}
+
+
+def order_final_state(state):
+    '''
+    Sorts final state objects into order expected by FSA.
+    
+    Sorts string of characters into ordr defined by "order." Invalid 
+    characters are ignored, and a warning is printed to stdout
+    
+    returns the sorted string
+    '''
+    order = "emtgj"
+    for obj in state:
+        if obj not in order:
+            print "invalid Final State object "\
+                "'%s' ignored" % obj
+            state = state.replace(obj, "")
+    return ''.join(sorted(state, key=lambda x: order.index(x)))
+ 
+
+def parseChannels(channels):
+    '''
+    Take a comma-separated string or listlike iterable of such strings 
+    indicating one or more channels or groups of channels, and yield
+    the individual channels. String can contain groups.
+    '''
+    if isinstance(channels, str):
+        chanList = [c.strip() for c in channels.lower().split(',')]
+        for ch in chanList:
+            if ch in _FINAL_STATE_GROUPS:
+                for c in _FINAL_STATE_GROUPS[ch]:
+                    yield c
+            else:
+                yield order_final_state(ch)
+    else:
+        try:
+            for ch in channels:
+                for c in parseChannels(ch):
+                    yield c
+        except TypeError:
+            print ("I only know how to deal with channels given as strings or "
+                   "listlike iterables of strings")
+            raise
+
+_channel_handling_object_map_ = {}
+def mapObjects(channel):
+    '''
+    From a channel of the form 'eemm' or 'eet', return a list of objects of 
+    the form ['e1','e2','m1','m2'] or ['e1','e2','t'].
+    Objects are in the order of the channel.
+    '''
+    try:
+        return _channel_handling_object_map_[channel]
+    except KeyError:
+        nObjects = OrderedDict()
+        counters = {}
+        
+        for obj in set(channel):
+            nObjects[obj] = channel.count(obj)
+            counters[obj] = 1
+    
+        objects = []
+        for obj in channel:
+            if nObjects[obj] == 1:
+                objects.append(obj)
+            else:
+                objects.append(obj+str(counters[obj]))
+                counters[obj] += 1
+        
+        # global declaration not needed
+        _channel_handling_object_map_[channel] = objects
+        return objects
+
+from FinalStateAnalysis.NtupleTools.ntuple_builder import _producer_translation
+def get_channel_suffix(state):
+    '''
+    Returns the suffix FSA puts on the end of produer and class names, e.g.
+    "ElecElecMuTau" for final state 'eemt'.
+    Doesn't sort, so state should already be in the right order.
+    '''
+    return ''.join(_producer_translation[obj] for obj in state)
+
+

--- a/NtupleTools/python/parameters/zz.py
+++ b/NtupleTools/python/parameters/zz.py
@@ -116,13 +116,27 @@ parameters = {
     # additional variables for ntuple
     'eventVariables' : PSet(
         zzEvVars,
-        HZZCategory = 'userFloat("HZZCategory")',
-        D_bkg_kin = 'userFloat("p0plus_VAJHU") / (userFloat("p0plus_VAJHU") + userFloat("bkg_VAMCFM"))',
-        D_bkg = 'userFloat("p0plus_VAJHU") * userFloat("p0plus_m4l") / '
-            '(userFloat("p0plus_VAJHU") * userFloat("p0plus_m4l") + userFloat("bkg_VAMCFM") * userFloat("bkg_m4l"))',
-        D_gg = 'userFloat("Dgg10_VAMCFM")',
-        D_g4 = 'userFloat("p0plus_VAJHU") / (userFloat("p0plus_VAJHU") + userFloat("p0minus_VAJHU"))',
-        Djet_VAJHU = '? evt.jets.size >= 2 ? userFloat("pvbf_VAJHU") / (userFloat("pvbf_VAJHU") + userFloat("phjj_VAJHU")) : -1',
+        HZZCategory = '? hasUserFloat("HZZCategory") ? userFloat("HZZCategory") : -1.',
+        D_bkg_kin = ('? hasUserFloat("p0plus_VAJHU") ? '
+                     'userFloat("p0plus_VAJHU") / (userFloat("p0plus_VAJHU") + '
+                     'userFloat("bkg_VAMCFM")) : '
+                     '-1.'),
+        D_bkg = ('? hasUserFloat("p0plus_VAJHU") ? '
+                 'userFloat("p0plus_VAJHU") * userFloat("p0plus_m4l") / '
+                 '(userFloat("p0plus_VAJHU") * userFloat("p0plus_m4l") + '
+                 'userFloat("bkg_VAMCFM") * userFloat("bkg_m4l")) : '
+                 '-1.'),
+        D_gg = ('? hasUserFloat("Dgg10_VAMCFM") ? '
+                'userFloat("Dgg10_VAMCFM") : '
+                '-1.'),
+        D_g4 = ('? hasUserFloat("p0plus_VAJHU") ? '
+                'userFloat("p0plus_VAJHU") / (userFloat("p0plus_VAJHU") + '
+                'userFloat("p0minus_VAJHU")) : '
+                '-1.'),
+        Djet_VAJHU = ('? evt.jets.size >= 2 && hasUserFloat("pvbf_VAJHU") ? '
+                      'userFloat("pvbf_VAJHU") / (userFloat("pvbf_VAJHU") + '
+                      'userFloat("phjj_VAJHU")) : '
+                      '-1.'),
         muVeto = 'vetoMuons(0.05, \'userFloat(\\\"HZZ4lIDPass\\\") > 0.5\').size()',
         muVetoIso = 'vetoMuons(0.05, \'userFloat(\\\"HZZ4lIDPass\\\") > 0.5 && userFloat(\\\"HZZ4lIsoPass\\\") > 0.5\').size()',
         muVetoTight = 'vetoMuons(0.05, \'userFloat(\\\"HZZ4lIDPassTight\\\") > 0.5\').size()',

--- a/NtupleTools/test/make_ntuples_cfg.py
+++ b/NtupleTools/test/make_ntuples_cfg.py
@@ -60,7 +60,7 @@ import os
 import copy
 from FinalStateAnalysis.NtupleTools.hzg_sync_mod import set_passthru
 from FinalStateAnalysis.NtupleTools.ntuple_builder import \
-    make_ntuple, add_ntuple, _producer_translation
+    make_ntuple, add_ntuple
 from FinalStateAnalysis.Utilities.version import cmssw_major_version, \
     cmssw_minor_version
 import PhysicsTools.PatAlgos.tools.helpers as helpers
@@ -780,6 +780,7 @@ produce_final_states(process,
                      output_to_keep, 
                      process.buildFSASeq,
                      'puTagDoesntMatter', 
+                     options.channels,
                      buildFSAEvent=True,
                      noTracks=True, 
                      runMVAMET=options.runMVAMET,
@@ -799,6 +800,7 @@ for fs in additional_fs:
                          output_to_keep, 
                          getattr(process,'buildFSASeq{0}'.format(fs)),
                          'puTagDoesntMatter', 
+                         options.channels,
                          buildFSAEvent=True,
                          noTracks=True, 
                          runMVAMET=options.runMVAMET,
@@ -821,98 +823,64 @@ process.source.inputCommands = cms.untracked.vstring(
 
 suffix = '' # most analyses don't need to modify the final states
 
-if options.hzz and (options.channels == 'zz' or any(len(c)==4 for c in options.channels.split(','))):
+# turn options.channels into actual channels
+from FinalStateAnalysis.NtupleTools.channel_handling import parseChannels, \
+    get_channel_suffix
+
+if options.hzz:
     process.embedHZZSeq = cms.Sequence()
     # Embed matrix elements in relevant final states
     suffix = "HZZ"
-    for quadFS in ['ElecElecElecElec', 
-                   'ElecElecMuMu',
-                   'MuMuMuMu']:
-        oldName = "finalState%s"%quadFS
-        embedCategoryProducer = cms.EDProducer(
-            "MiniAODHZZCategoryEmbedder",
-            src = cms.InputTag(oldName),
-            tightLepCut = cms.string('userFloat("HZZ4lIDPassTight") > 0.5 && userFloat("HZZ4lIsoPass") > 0.5'),
-            bDiscriminator = cms.string("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
-            bDiscriminantCut = cms.double(0.89),
-            )
-        # give the FS collection an intermediate name, with an identifying suffix
-        intermediateName = oldName + "HZZCategory"
-        setattr(process, intermediateName, embedCategoryProducer)
-        process.embedHZZSeq += embedCategoryProducer
-        
-        embedMEProducer = cms.EDProducer(
-            "MiniAODHZZMEEmbedder%s"%quadFS,
-            src = cms.InputTag(intermediateName),
-            processes = cms.vstring("p0plus_VAJHU",
-                                    "p0minus_VAJHU",
-                                    "Dgg10_VAMCFM",
-                                    "bkg_VAMCFM",
-                                    "phjj_VAJHU",
-                                    "pvbf_VAJHU",
-                                    ),
-            fsrLabel = cms.string("dretFSRCand"),
-            )
-        # give the FS collection the same name as before, but with an identifying suffix
+    for ch in parseChannels(options.channels):
+        prodSuffix = get_channel_suffix(ch)
+        oldName = "finalState%s"%prodSuffix
         newName = oldName + suffix
-        setattr(process, newName, embedMEProducer)
-        process.embedHZZSeq += embedMEProducer
+
+        if len(ch) == 4:
+            # 4l final states might be higgses, so do some higgs analysis
+            embedCategoryProducer = cms.EDProducer(
+                "MiniAODHZZCategoryEmbedder",
+                src = cms.InputTag(oldName),
+                tightLepCut = cms.string('userFloat("HZZ4lIDPassTight") > 0.5 && userFloat("HZZ4lIsoPass") > 0.5'),
+                bDiscriminator = cms.string("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
+                bDiscriminantCut = cms.double(0.89),
+                )
+            # give the FS collection an intermediate name, with an identifying suffix
+            intermediateName = oldName + "HZZCategory"
+            setattr(process, intermediateName, embedCategoryProducer)
+            process.embedHZZSeq += embedCategoryProducer
+            
+            embedMEProducer = cms.EDProducer(
+                "MiniAODHZZMEEmbedder%s"%prodSuffix,
+                src = cms.InputTag(intermediateName),
+                processes = cms.vstring("p0plus_VAJHU",
+                                        "p0minus_VAJHU",
+                                        "Dgg10_VAMCFM",
+                                        "bkg_VAMCFM",
+                                        "phjj_VAJHU",
+                                        "pvbf_VAJHU",
+                                        ),
+                fsrLabel = cms.string("dretFSRCand"),
+                )
+            # give the FS collection the same name as before, but with an identifying suffix
+            setattr(process, newName, embedMEProducer)
+            process.embedHZZSeq += embedMEProducer
+        else:
+            # Copy the other final states to keep naming consistent
+            copier = cms.EDProducer(
+                "PATFinalStateCopier",
+                src = cms.InputTag(oldName),
+                )
+            setattr(process, newName, copier)
+            process.embedHZZSeq += copier
             
     process.embedHZZ = cms.Path(process.embedHZZSeq)
     process.schedule.append(process.embedHZZ)
         
 
 
-_FINAL_STATE_GROUPS = {
-    'zh': 'eeem, eeet, eemt, eett, emmm, emmt, mmmt, mmtt',
-    'zz': 'eeee, eemm, mmmm',
-    'zgg': 'eegg, mmgg',
-    'llt': 'emt, mmt, eet, mmm, emm, mm, ee, em',
-    'zg': 'mmg, eeg',
-    'zgxtra': 'mgg, emg, egg',
-    'dqm': 'e,m,t,g,j',
-    '3lep': 'eee, eem, eet, emm, emt, ett, mmm, mmt, mtt, ttt',
-    '4lep': 'eeee, eeem, eeet, eemm, eemt, eett, emmm, emmt, emtt, ettt, mmmm, mmmt, mmtt, mttt, tttt',
-}
-
 # run dqm
 if options.runDQM: options.channels = 'dqm'
-
-# Generate analyzers which build the desired final states.
-final_states = [x.strip() for x in options.channels.split(',')]
-
-
-def order_final_state(state):
-    '''
-    Sorts final state objects into order expected by FSA.
-    
-    Sorts string of characters into ordr defined by "order." Invalid 
-    characters are ignored, and a warning is pribted to stdout
-    
-    returns the sorted string
-    '''
-    order = "emtgj"
-    for obj in state:
-        if obj not in order:
-            print "invalid Final State object "\
-                "'%s' ignored" % obj
-            state = state.replace(obj, "")
-    return ''.join(sorted(state, key=lambda x: order.index(x)))
- 
-def expanded_final_states(input):
-    for fs in input:
-        if fs in _FINAL_STATE_GROUPS:
-            for subfs in _FINAL_STATE_GROUPS[fs].split(','):
-                yield subfs.strip()
-        else:
-            yield fs
-
-def get_producer_suffix(state):
-    '''
-    Returns the suffix FSA puts on the end of produer and class names, e.g.
-    "ElecElecMuTau" for final state 'eemt'.
-    '''
-    return ''.join(_producer_translation[obj] for obj in order_final_state(state))
 
 
 if options.keepPat:
@@ -930,7 +898,7 @@ if options.keepPat:
     else:
         process.finalStateCleaning = cms.Sequence()
 
-        for fs in expanded_final_states(final_states):
+        for fs in parseChannels(options.channels):
             fsCuts = cms.vstring()
             for name, cut in uniqueness_cuts(fs, ptCuts, etaCuts, 
                                              skimCuts=skimCuts,
@@ -940,12 +908,12 @@ if options.keepPat:
                 
             fsCleaner = cms.EDProducer(
                 "PATFinalStateSelector",
-                src = cms.InputTag("finalState%s%s"%(get_producer_suffix(fs), suffix)),
+                src = cms.InputTag("finalState%s%s"%(get_channel_suffix(fs), suffix)),
                 cuts = fsCuts,
                 )
             
             # give the producer a good name so it's easy to find the output
-            cleanerName = 'cleanedFinalState%s'%get_producer_suffix(fs)
+            cleanerName = 'cleanedFinalState%s'%get_channel_suffix(fs)
             setattr(process, cleanerName, fsCleaner)
             process.finalStateCleaning += fsCleaner
             
@@ -983,11 +951,10 @@ if options.keepPat:
     process.save = cms.EndPath(process.out)
     process.schedule.append(process.save)
 else:
-    print "Building ntuple for final states: %s" % ", ".join(final_states)
-    for final_state in expanded_final_states(final_states):
+    print "Building ntuple for final states: %s" % ", ".join(x.strip() for x in options.channels.split(','))
+    for final_state in parseChannels(options.channels):
         if additional_fs: print 'Adding ntuple {0}'.format(final_state)
         extraJets = options.nExtraJets
-        final_state = order_final_state(final_state)
         analyzer = make_ntuple(*final_state, 
                                 svFit=options.svFit, 
                                 dblhMode=options.dblhMode,

--- a/PatTools/python/patFinalStateProducers.py
+++ b/PatTools/python/patFinalStateProducers.py
@@ -23,6 +23,8 @@ from FinalStateAnalysis.Utilities.cfgtools import chain_sequence
 import PhysicsTools.PatAlgos.tools.helpers as helpers
 import itertools
 
+from FinalStateAnalysis.NtupleTools.channel_handling import parseChannels, \
+    mapObjects, get_channel_suffix
 
 def _subsort(iterables):
     for iterable in iterables:
@@ -42,7 +44,7 @@ def _combinatorics(items, n):
 
 
 def produce_final_states(process, daughter_collections, output_commands,
-                         sequence, puTag, buildFSAEvent=True,
+                         sequence, puTag, channels='', buildFSAEvent=True,
                          noTracks=False, runMVAMET=False, hzz=False,
                          rochCor="", eleCor="", postfix='',
                          **kwargs):
@@ -156,13 +158,13 @@ def produce_final_states(process, daughter_collections, output_commands,
 
 
     # Now build all combinatorics for E/Mu/Tau/Photon
-    object_types = [
-        ('Elec', cms.InputTag(src["electrons"])),
-        ('Mu', cms.InputTag(src["muons"])),
-        ('Tau', cms.InputTag(src["taus"])),
-        ('Jet', cms.InputTag(src["jets"])),
-        ('Pho', cms.InputTag(src["photons"])),
-        ]
+    object_types = {
+        'e' : cms.InputTag(src["electrons"]),
+        'm' : cms.InputTag(src["muons"]),
+        't' : cms.InputTag(src["taus"]),
+        'j' : cms.InputTag(src["jets"]),
+        'g' : cms.InputTag(src["photons"]),
+        }
 
     # keep the collections we used to build the final states 
     for name, label in src.iteritems():
@@ -186,174 +188,56 @@ def produce_final_states(process, daughter_collections, output_commands,
     crossCleaning = kwargs.get('crossCleaning','smallestDeltaR() > 0.3')
 
 
-    # build single object pairs
-    singleObjName = 'buildSingleObjects{0}'.format(postfix)
-    singleObjSeq = cms.Sequence()
-    for object in object_types:
-        # Define some basic selections for building combinations
-        cuts = [crossCleaning]  # basic x-cleaning
+    builderSeqs = {}
 
-        producer = cms.EDProducer(
-            "PAT%sFinalStateProducer" % object[0],
-            evtSrc=cms.InputTag("patFinalStateEventProducer{0}".format(postfix)),
-            leg1Src=object[1],
-            # X-cleaning
-            cut=cms.string(' & '.join(cuts))
-        )
-        producer_name = "finalState{0}{1}".format(object[0],postfix)
-        setattr(process, producer_name + "Raw", producer)
-        singleObjSeq += producer
-        # Embed the other collections
-        embedder_seq = helpers.cloneProcessingSnippet(
-            process, getattr(process,embedObjName), producer_name)
-        singleObjSeq += embedder_seq
-        # Do some trickery so the final module has a nice output name
-        final_module_name = chain_sequence(embedder_seq, producer_name + "Raw")
-        final_module = cms.EDProducer(
-            "PATFinalStateCopier", src=final_module_name)
-        setattr(process, producer_name, final_module)
-        singleObjSeq += final_module
-        setattr(process, producer_name, final_module)
-    setattr(process,singleObjName,singleObjSeq)
-    sequence += getattr(process,singleObjName)
+    for channel in parseChannels(channels):
 
-    # Build di-object pairs
-    doubleObjName = 'buildDiObjects{0}'.format(postfix)
-    doubleObjSeq = cms.Sequence()
-    for diobject in _combinatorics(object_types, 2):
-        # Don't build two jet states
-        if (diobject[0][0], diobject[1][0]) == ('Tau', 'Pho'):
-            continue
-        if (diobject[0][0], diobject[1][0]) == ('Tau', 'Jet'):
-            continue
-        if (diobject[0][0], diobject[1][0]) == ('Jet', 'Pho'):
-            continue
-        if (diobject[0][0], diobject[1][0]) == ('Jet', 'Jet'):
-            continue
+        # build single object final states
+        producerSuffix = get_channel_suffix(channel)
 
         # Define some basic selections for building combinations
         cuts = [crossCleaning]  # basic x-cleaning
 
+        nObj = len(channel)
+        if nObj not in builderSeqs:
+            builderSeqs[nObj] = cms.Sequence()
+
         producer = cms.EDProducer(
-            "PAT%s%sFinalStateProducer" % (diobject[0][0], diobject[1][0]),
+            "PAT%sFinalStateProducer" % producerSuffix,
             evtSrc=cms.InputTag("patFinalStateEventProducer{0}".format(postfix)),
-            leg1Src=diobject[0][1],
-            leg2Src=diobject[1][1],
             # X-cleaning
             cut=cms.string(' & '.join(cuts))
-        )
-        producer_name = "finalState{0}{1}{2}".format(diobject[0][0], diobject[1][0], postfix)
+            )
+        for i in range(nObj):
+            setattr(producer, 'leg{}Src'.format(i+1),
+                    object_types[channel[i]])
+    
+        producer_name = "finalState{0}{1}".format(producerSuffix,postfix)
         setattr(process, producer_name + "Raw", producer)
-        doubleObjSeq += producer
+        builderSeqs[nObj] += producer
         # Embed the other collections
         embedder_seq = helpers.cloneProcessingSnippet(
             process, getattr(process,embedObjName), producer_name)
-        doubleObjSeq += embedder_seq
+        builderSeqs[nObj] += embedder_seq
         # Do some trickery so the final module has a nice output name
         final_module_name = chain_sequence(embedder_seq, producer_name + "Raw")
         final_module = cms.EDProducer(
             "PATFinalStateCopier", src=final_module_name)
         setattr(process, producer_name, final_module)
-        doubleObjSeq += final_module
-        setattr(process, producer_name, final_module)
-    setattr(process,doubleObjName,doubleObjSeq)
-    sequence += getattr(process,doubleObjName)
+        builderSeqs[nObj] += final_module
 
-    # Build tri-lepton pairs
-    tripleObjName = 'buildTriObjects{0}'.format(postfix)
-    tripleObjSeq = cms.Sequence()
-    for triobject in _combinatorics(object_types, 3):
-        n_taus = [x[0] for x in triobject].count('Tau')
-        n_phos = [x[0] for x in triobject].count('Pho')
-        n_muons = [x[0] for x in triobject].count('Mu')
-        n_jets = [x[0] for x in triobject].count('Jet')
+    for nObj, seq in builderSeqs.iteritems():
+        if nObj == 1:
+            name = 'buildSingleObjects{0}'.format(postfix)
+        if nObj == 2:
+            name = 'buildDiObjects{0}'.format(postfix)
+        if nObj == 3:
+            name = 'buildTriObjects{0}'.format(postfix)
+        if nObj == 4:
+            name = 'buildQuadObjects{0}'.format(postfix)
 
-        if n_phos > 2:
-            continue
-        if n_taus and n_phos:
-            continue
-        if n_jets > 0 and not (n_jets == 2 and n_muons == 1):
-            continue
-
-        # Define some basic selections for building combinations
-        cuts = [crossCleaning]  # basic x-cleaning
-
-        producer = cms.EDProducer(
-            "PAT%s%s%sFinalStateProducer" %
-            (triobject[0][0], triobject[1][0], triobject[2][0]),
-            evtSrc=cms.InputTag("patFinalStateEventProducer{0}".format(postfix)),
-            leg1Src=triobject[0][1],
-            leg2Src=triobject[1][1],
-            leg3Src=triobject[2][1],
-            # X-cleaning
-            cut=cms.string(' & '.join(cuts))
-        )
-        producer_name = "finalState{0}{1}{2}{3}".format(
-            triobject[0][0], triobject[1][0], triobject[2][0], postfix)
-        setattr(process, producer_name + "Raw", producer)
-        tripleObjSeq += producer
-        # Embed the other collections
-        embedder_seq = helpers.cloneProcessingSnippet(
-            process, getattr(process,embedObjName), producer_name)
-        tripleObjSeq += embedder_seq
-        # Do some trickery so the final module has a nice output name
-        final_module_name = chain_sequence(embedder_seq, producer_name + "Raw")
-        final_module = cms.EDProducer(
-            "PATFinalStateCopier", src=final_module_name)
-        setattr(process, producer_name, final_module)
-        tripleObjSeq += final_module
-    setattr(process,tripleObjName,tripleObjSeq)
-    sequence += getattr(process,tripleObjName)
-
-    # Build 4 lepton final states
-    quadObjName = 'buildQuadObjects{0}'.format(postfix)
-    quadObjSeq = cms.Sequence()
-    for quadobject in _combinatorics(object_types, 4):
-        # Don't build states with more than 2 hadronic taus or phos
-        n_taus = [x[0] for x in quadobject].count('Tau')
-        n_phos = [x[0] for x in quadobject].count('Pho')
-        n_jets = [x[0] for x in quadobject].count('Jet')
-
-        if n_phos > 2:
-            continue
-        if n_taus and n_phos:
-            continue
-        if n_jets > 0:
-            continue
-
-        cuts = [crossCleaning]  # basic x-cleaning
-
-        producer = cms.EDProducer(
-            "PAT%s%s%s%sFinalStateProducer" %
-            (quadobject[0][0], quadobject[1][0], quadobject[2][0],
-             quadobject[3][0]),
-            evtSrc=cms.InputTag("patFinalStateEventProducer{0}".format(postfix)),
-            leg1Src=quadobject[0][1],
-            leg2Src=quadobject[1][1],
-            leg3Src=quadobject[2][1],
-            leg4Src=quadobject[3][1],
-            # X-cleaning
-            cut=cms.string(' & '.join(cuts))
-        )
-        producer_name = "finalState{0}{1}{2}{3}{4}".format(
-            quadobject[0][0], quadobject[1][0], quadobject[2][0],
-            quadobject[3][0], postfix
-        )
-        setattr(process, producer_name + "Raw", producer)
-        quadObjSeq += producer
-        # Embed the other collections
-        embedder_seq = helpers.cloneProcessingSnippet(
-            process, getattr(process,embedObjName), producer_name)
-        quadObjSeq += embedder_seq
-        # Do some trickery so the final module has a nice output name
-        final_module_name = chain_sequence(embedder_seq, producer_name + "Raw")
-        final_module = cms.EDProducer(
-            "PATFinalStateCopier", src=final_module_name)
-        setattr(process, producer_name, final_module)
-        quadObjSeq += final_module
-    setattr(process,quadObjName,quadObjSeq)
-    sequence += getattr(process,quadObjName)
-
+        setattr(process,name,seq)
+        sequence += getattr(process,name)
 
 if __name__ == "__main__":
     import doctest

--- a/recipe/recipe_13TeV.sh
+++ b/recipe/recipe_13TeV.sh
@@ -27,7 +27,7 @@ if [ "$HZZ" = "1" ]; then
     echo "Checking out ZZ MELA and Higgs combine"
     git clone https://github.com/cms-analysis/HiggsAnalysis-ZZMatrixElement.git ZZMatrixElement
     pushd ZZMatrixElement
-    git checkout -b from-V00-02-01 V00-02-01
+    git checkout -b from-V00-02-01-patch1 V00-02-01-patch1
     popd
     git clone -b 74x-root6 https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
 fi


### PR DESCRIPTION
Instead of building all `PATFinalState` objects for all channels (presumably done only as a relic of FSA's old days as a PATTuplizer), build only those that will end up in the ntuple. On a test making 4l ntuples for 10000 VBF Higgs events, this gives an O(10%) reduction in CPU and memory use. The gain on average will probably be smaller, especially for memory use, but should be bigger for events with a lot of objects (e.g. ttH, or some pathological data events we've found), which have caused some trouble in computing land recently. 
