### PR TITLE
removing mvamet from recipe as not working yet in 80X

### DIFF
--- a/recipe/recipe_13TeV.sh
+++ b/recipe/recipe_13TeV.sh
@@ -42,8 +42,9 @@ popd
 # Checkout mva met code
 git cms-addpkg RecoMET/METPUSubtraction
 git cms-addpkg DataFormats/METReco
-git remote add -f mvamet https://github.com/rfriese/cmssw.git
-git checkout MVAMET2_beta_0.6 -b mvamet
+#add the MVA MET when it is working in CMSSW8XY
+#git remote add -f mvamet https://github.com/rfriese/cmssw.git
+#git checkout MVAMET2_beta_0.6 -b mvamet
 
 
 popd


### PR DESCRIPTION
MVA MET gives error in compiling.  It is not used by LFV Higgs analysis. If nobody uses it, we can remove it from the recipe_13.sh until there is a working recipe from CMS
