### PR TITLE
Mini aod dev 80 x

### DIFF
--- a/DataFormats/interface/PATFinalState.h
+++ b/DataFormats/interface/PATFinalState.h
@@ -403,8 +403,8 @@ class PATFinalState : public pat::PATObject<reco::LeafCandidate> {
     const float daughterUserCandIsoContribution(const size_t i, const std::string& label) const;
 
     // Matching FS object to L1 iso taus
-    const float l1extraIsoTauMatching(const size_t i) const;
-    const float doubleL1extraIsoTauMatching(const size_t i, const size_t j) const;
+    //const float l1extraIsoTauMatching(const size_t i) const;
+    //const float doubleL1extraIsoTauMatching(const size_t i, const size_t j) const;
 
   private:
     edm::Ptr<PATFinalStateEvent> event_;

--- a/DataFormats/interface/PATFinalStateEvent.h
+++ b/DataFormats/interface/PATFinalStateEvent.h
@@ -66,7 +66,7 @@ class PATFinalStateEvent {
         const edm::TriggerNames& names,
         const pat::PackedTriggerPrescales& triggerPrescale,
         const edm::TriggerResults& triggerResults,
-        const std::vector<l1extra::L1JetParticle>& l1extraIsoTaus, 
+        //const std::vector<l1extra::L1JetParticle>& l1extraIsoTaus, 
         const std::vector<PileupSummaryInfo>& puInfo,
         const lhef::HEPEUP& hepeup, // Les Houches info
         const reco::GenParticleRefProd& genParticles,
@@ -108,7 +108,7 @@ class PATFinalStateEvent {
     const edm::TriggerNames& names() const;
     const pat::PackedTriggerPrescales& trigPrescale() const;
     const edm::TriggerResults& trigResults() const;
-    const std::vector<l1extra::L1JetParticle>& l1extraIsoTaus() const;
+    //const std::vector<l1extra::L1JetParticle>& l1extraIsoTaus() const;
 
     /*  These methods will be deprecated! */
     /// Get PFMET
@@ -223,7 +223,7 @@ class PATFinalStateEvent {
     edm::TriggerNames names_;
     pat::PackedTriggerPrescales triggerPrescale_;
     edm::TriggerResults triggerResults_;
-    std::vector<l1extra::L1JetParticle> l1extraIsoTaus_;
+    //std::vector<l1extra::L1JetParticle> l1extraIsoTaus_;
     edm::Ptr<reco::Vertex> pv_;
     std::vector<edm::Ptr<reco::Vertex>> recoVertices_;
     edm::Ptr<pat::MET> met_;

--- a/DataFormats/src/PATFinalState.cc
+++ b/DataFormats/src/PATFinalState.cc
@@ -1655,56 +1655,56 @@ const float PATFinalState::daughterUserCandIsoContribution(const size_t i, const
   return 0.;
 }
 
-const float PATFinalState::l1extraIsoTauMatching(const size_t i) const
-{
-    std::vector< l1extra::L1JetParticle > isoTaus = evt()->l1extraIsoTaus();
-    //for (int i = 0; i < isoTaus.size(); ++i) {
-    for ( auto isoTau : isoTaus ) {
-        //std::cout << " - l1 p4: " << isoTau.p4() << std::endl;
-        if (isoTau.pt() < 28) {
-            //std::cout << " --- Pt small" << std::endl;
-            continue;}
-        float dR = reco::deltaR(daughter(i)->p4(), isoTau.p4() );
-        //std::cout << " --- dR: " << dR << std::endl;
-        if (dR < 0.5) return 1;
-    }
-
-    return 0.0;
-}
-
-const float PATFinalState::doubleL1extraIsoTauMatching(const size_t i, const size_t j) const
-{
-    std::vector< l1extra::L1JetParticle > isoTaus = evt()->l1extraIsoTaus();
-    //for (int i = 0; i < isoTaus.size(); ++i) {
-    int p1MatchCnt = 0;
-    int p2MatchCnt = 0;
-    int bothMatchCnt = 0;
-    
-    // check for matching to each tau, pay attention to objects that match
-    // both taus
-    for ( auto isoTau : isoTaus ) {
-        //std::cout << " - l1 p4: " << isoTau.p4() << std::endl;
-        if (isoTau.pt() < 28) {
-            //std::cout << " --- Pt small" << std::endl;
-            continue;}
-        float dR1 = reco::deltaR(daughter(i)->p4(), isoTau.p4() );
-        float dR2 = reco::deltaR(daughter(j)->p4(), isoTau.p4() );
-        //std::cout << " --- dR1: " << dR1 << std::endl;
-        //std::cout << " --- dR2: " << dR2 << std::endl;
-        if (dR1 < 0.5) p1MatchCnt += 1;
-        if (dR2 < 0.5) p2MatchCnt += 1;
-        if (dR1 < 0.5 && dR2 < 0.5) bothMatchCnt += 1;
-    }
- 
-    //std::cout << "p1Match "<<p1MatchCnt<<" p2 "<<p2MatchCnt<<" both "<<bothMatchCnt<<std::endl;
-    // both match different iso taus
-    if (p1MatchCnt > 0 && p2MatchCnt > 0 && bothMatchCnt == 0) return 1.0;
-    // both share a single iso tau, but one tau matching 2 iso objects so
-    // it's okay
-    else if ((p1MatchCnt + p2MatchCnt) == 3 && bothMatchCnt == 1) return 2.0;
-    // This should never happen...probably
-    else if ((p1MatchCnt + p2MatchCnt) == 4 && bothMatchCnt == 2) return 3.0;
-   
-    return 0.0;
-}
+//const float PATFinalState::l1extraIsoTauMatching(const size_t i) const
+//{
+//    std::vector< l1extra::L1JetParticle > isoTaus = evt()->l1extraIsoTaus();
+//    //for (int i = 0; i < isoTaus.size(); ++i) {
+//    for ( auto isoTau : isoTaus ) {
+//        //std::cout << " - l1 p4: " << isoTau.p4() << std::endl;
+//        if (isoTau.pt() < 28) {
+//            //std::cout << " --- Pt small" << std::endl;
+//            continue;}
+//        float dR = reco::deltaR(daughter(i)->p4(), isoTau.p4() );
+//        //std::cout << " --- dR: " << dR << std::endl;
+//        if (dR < 0.5) return 1;
+//    }
+//
+//    return 0.0;
+//}
+//
+//const float PATFinalState::doubleL1extraIsoTauMatching(const size_t i, const size_t j) const
+//{
+//    std::vector< l1extra::L1JetParticle > isoTaus = evt()->l1extraIsoTaus();
+//    //for (int i = 0; i < isoTaus.size(); ++i) {
+//    int p1MatchCnt = 0;
+//    int p2MatchCnt = 0;
+//    int bothMatchCnt = 0;
+//    
+//    // check for matching to each tau, pay attention to objects that match
+//    // both taus
+//    for ( auto isoTau : isoTaus ) {
+//        //std::cout << " - l1 p4: " << isoTau.p4() << std::endl;
+//        if (isoTau.pt() < 28) {
+//            //std::cout << " --- Pt small" << std::endl;
+//            continue;}
+//        float dR1 = reco::deltaR(daughter(i)->p4(), isoTau.p4() );
+//        float dR2 = reco::deltaR(daughter(j)->p4(), isoTau.p4() );
+//        //std::cout << " --- dR1: " << dR1 << std::endl;
+//        //std::cout << " --- dR2: " << dR2 << std::endl;
+//        if (dR1 < 0.5) p1MatchCnt += 1;
+//        if (dR2 < 0.5) p2MatchCnt += 1;
+//        if (dR1 < 0.5 && dR2 < 0.5) bothMatchCnt += 1;
+//    }
+// 
+//    //std::cout << "p1Match "<<p1MatchCnt<<" p2 "<<p2MatchCnt<<" both "<<bothMatchCnt<<std::endl;
+//    // both match different iso taus
+//    if (p1MatchCnt > 0 && p2MatchCnt > 0 && bothMatchCnt == 0) return 1.0;
+//    // both share a single iso tau, but one tau matching 2 iso objects so
+//    // it's okay
+//    else if ((p1MatchCnt + p2MatchCnt) == 3 && bothMatchCnt == 1) return 2.0;
+//    // This should never happen...probably
+//    else if ((p1MatchCnt + p2MatchCnt) == 4 && bothMatchCnt == 2) return 3.0;
+//   
+//    return 0.0;
+//}
 

--- a/DataFormats/src/PATFinalStateEvent.cc
+++ b/DataFormats/src/PATFinalStateEvent.cc
@@ -99,7 +99,7 @@ PATFinalStateEvent::PATFinalStateEvent(
     const edm::TriggerNames& names,
     const pat::PackedTriggerPrescales& triggerPrescale,
     const edm::TriggerResults& triggerResults,
-    const std::vector<l1extra::L1JetParticle>& l1extraIsoTaus,
+    //const std::vector<l1extra::L1JetParticle>& l1extraIsoTaus,
     const std::vector<PileupSummaryInfo>& puInfo,
     const lhef::HEPEUP& hepeup,
     const reco::GenParticleRefProd& genParticles,
@@ -125,7 +125,7 @@ PATFinalStateEvent::PATFinalStateEvent(
   names_(names),
   triggerPrescale_(triggerPrescale),
   triggerResults_(triggerResults),
-  l1extraIsoTaus_(l1extraIsoTaus),
+  //l1extraIsoTaus_(l1extraIsoTaus),
   pv_(pv),
   recoVertices_(recoVertices),
   met_(met),
@@ -195,8 +195,8 @@ const pat::PackedTriggerPrescales& PATFinalStateEvent::trigPrescale() const {
 const edm::TriggerResults& PATFinalStateEvent::trigResults() const {
   return triggerResults_; }
 
-const std::vector<l1extra::L1JetParticle>& PATFinalStateEvent::l1extraIsoTaus() const {
-  return l1extraIsoTaus_; }
+//const std::vector<l1extra::L1JetParticle>& PATFinalStateEvent::l1extraIsoTaus() const {
+//  return l1extraIsoTaus_; }
 
 const edm::Ptr<pat::MET>& PATFinalStateEvent::met() const {
   return met_;

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -37,7 +37,8 @@
    <version ClassVersion="10" checksum="4038526841"/>
   </class>
 
-  <class name="PATFinalStateEvent" ClassVersion="20">
+  <class name="PATFinalStateEvent" ClassVersion="21">
+   <version ClassVersion="21" checksum="2996611432"/>
    <version ClassVersion="20" checksum="3500615424"/>
    <version ClassVersion="19" checksum="826230136"/>
    <version ClassVersion="18" checksum="458817852"/>

--- a/MetaData/tuples/MiniAOD-13TeV_Data.json
+++ b/MetaData/tuples/MiniAOD-13TeV_Data.json
@@ -53,8 +53,28 @@
   "data_MuonEG_Run2016B_25ns" :  "/MuonEG/Run2016B-PromptReco-v2/MINIAOD",
   "data_Tau_Run2016B_25ns" :  "/Tau/Run2016B-PromptReco-v2/MINIAOD",
   "data_SingleMuon_Run2016B_PromptReco-v2_25ns":"/SingleMuon/Run2016B-PromptReco-v2/MINIAOD",
-  "data_SingleElectron_Run2016B_PromptReco-v2_25ns":"/SingleElectron/Run2016B-PromptReco-v2/MINIAOD"
+  "data_SingleElectron_Run2016B_PromptReco-v2_25ns":"/SingleElectron/Run2016B-PromptReco-v2/MINIAOD",
 
+  "data_DoubleEG_Run2016C_25ns" :  "/DoubleEG/Run2016C-PromptReco-v2/MINIAOD",
+  "data_DoubleMuon_Run2016C_25ns" :  "/DoubleMuon/Run2016C-PromptReco-v2/MINIAOD",
+  "data_MuonEG_Run2016C_25ns" :  "/MuonEG/Run2016C-PromptReco-v2/MINIAOD",
+  "data_Tau_Run2016C_25ns" :  "/Tau/Run2016C-PromptReco-v2/MINIAOD",
+  "data_SingleMuon_Run2016C_PromptReco-v2_25ns":"/SingleMuon/Run2016C-PromptReco-v2/MINIAOD",
+  "data_SingleElectron_Run2016C_PromptReco-v2_25ns":"/SingleElectron/Run2016C-PromptReco-v2/MINIAOD",
+
+  "data_DoubleEG_Run2016D_25ns" :  "/DoubleEG/Run2016D-PromptReco-v2/MINIAOD",
+  "data_DoubleMuon_Run2016D_25ns" :  "/DoubleMuon/Run2016D-PromptReco-v2/MINIAOD",
+  "data_MuonEG_Run2016D_25ns" :  "/MuonEG/Run2016D-PromptReco-v2/MINIAOD",
+  "data_Tau_Run2016D_25ns" :  "/Tau/Run2016D-PromptReco-v2/MINIAOD",
+  "data_SingleMuon_Run2016D_PromptReco-v2_25ns":"/SingleMuon/Run2016D-PromptReco-v2/MINIAOD",
+  "data_SingleElectron_Run2016D_PromptReco-v2_25ns":"/SingleElectron/Run2016D-PromptReco-v2/MINIAOD",
+
+  "data_DoubleEG_Run2016E_25ns" :  "/DoubleEG/Run2016E-PromptReco-v2/MINIAOD",
+  "data_DoubleMuon_Run2016E_25ns" :  "/DoubleMuon/Run2016E-PromptReco-v2/MINIAOD",
+  "data_MuonEG_Run2016E_25ns" :  "/MuonEG/Run2016E-PromptReco-v2/MINIAOD",
+  "data_Tau_Run2016E_25ns" :  "/Tau/Run2016E-PromptReco-v2/MINIAOD",
+  "data_SingleMuon_Run2016E_PromptReco-v2_25ns":"/SingleMuon/Run2016E-PromptReco-v2/MINIAOD",
+  "data_SingleElectron_Run2016E_PromptReco-v2_25ns":"/SingleElectron/Run2016E-PromptReco-v2/MINIAOD"
 }
 
 

--- a/NtupleTools/python/parameters/azh.py
+++ b/NtupleTools/python/parameters/azh.py
@@ -22,23 +22,24 @@ parameters = {
     },
 
     # selections on all objects whether they're included in final states or not, done immediately after necessary variables are embedded
-    'preselection' : OrderedDict(
-        [
-            # Remove jets that overlap our leptons
-            ('j', { # Made pt requirement for E/Mu to clean an overlapping jet so
-                    # that this never happens
-                    'selection' : 'pt > 20 && abs(eta) < 4.7 && userFloat("idLoose") > 0.5',
-                    'e' : {
-                        'deltaR' : 0.5,
-                        'selection' : 'userFloat("MVANonTrigWP90") > 0.5 && pt > 9999 && abs(eta) < 2.5',
-                        },
-                    'm' : {
-                        'deltaR' : 0.5,
-                        'selection' : 'isMediumMuon() > 0.5 && pt > 9999 && abs(eta) < 2.4',
-                        },
-                    }
-             )
-            ]),
+    'preselection' : OrderedDict(),
+        # Commented out because of 80X jet cleaning memory leak
+        #[
+        #    # Remove jets that overlap our leptons
+        #    ('j', { # Made pt requirement for E/Mu to clean an overlapping jet so
+        #            # that this never happens
+        #            'selection' : 'pt > 20 && abs(eta) < 4.7 && userFloat("idLoose") > 0.5',
+        #            'e' : {
+        #                'deltaR' : 0.5,
+        #                'selection' : 'userFloat("MVANonTrigWP90") > 0.5 && pt > 9999 && abs(eta) < 2.5',
+        #                },
+        #            'm' : {
+        #                'deltaR' : 0.5,
+        #                'selection' : 'isMediumMuon() > 0.5 && pt > 9999 && abs(eta) < 2.4',
+        #                },
+        #            }
+        #     )
+        #    ]),
 
     # selections to include object in final state (should be looser than analysis selections)
     # Based on default finalSelection, this is a little tighter for muons so we keep the min Pt Mu for our triggers
@@ -184,7 +185,7 @@ parameters = {
 
     'tauVariables' : PSet(
         
-        objectL1IsoTauMatch = 'l1extraIsoTauMatching({object_idx})',
+        #objectL1IsoTauMatch = 'l1extraIsoTauMatching({object_idx})',
         # Sync Triggers
         objectDoubleTau40Filter = 'matchToHLTFilter({object_idx}, "hltDoublePFTau40TrackPt1MediumIsolationDz02Reg", 0.5)',
         objectMatchesDoubleTau40Path      = r'matchToHLTPath({object_idx}, "HLT_DoubleMediumIsoPFTau40_Trk1_eta2p1_Reg_v\\d+", 0.5)',
@@ -222,6 +223,6 @@ parameters = {
         object1_object2_MvaMetCovMatrix10 = 'getMVAMET({object1_idx},{object2_idx}).at(3)',
         object1_object2_MvaMetCovMatrix01 = 'getMVAMET({object1_idx},{object2_idx}).at(4)',
         object1_object2_MvaMetCovMatrix11 = 'getMVAMET({object1_idx},{object2_idx}).at(5)',
-        object1_object2_doubleL1IsoTauMatch = 'doubleL1extraIsoTauMatching({object1_idx},{object2_idx})',
+        #object1_object2_doubleL1IsoTauMatch = 'doubleL1extraIsoTauMatching({object1_idx},{object2_idx})',
     ),
 }

--- a/NtupleTools/python/parameters/ztt.py
+++ b/NtupleTools/python/parameters/ztt.py
@@ -22,23 +22,24 @@ parameters = {
     },
 
     # selections on all objects whether they're included in final states or not, done immediately after necessary variables are embedded
-    'preselection' : OrderedDict(
-        [
-            # Remove jets that overlap our leptons
-            ('j', { # Made pt requirement for E/Mu to clean an overlapping jet so
-                    # that this never happens
-                    'selection' : 'pt > 20 && abs(eta) < 4.7 && userFloat("idLoose") > 0.5',
-                    'e' : {
-                        'deltaR' : 0.5,
-                        'selection' : 'userFloat("MVANonTrigWP90") > 0.5 && pt > 9999 && abs(eta) < 2.5',
-                        },
-                    'm' : {
-                        'deltaR' : 0.5,
-                        'selection' : 'isMediumMuon() > 0.5 && pt > 9999 && abs(eta) < 2.4',
-                        },
-                    }
-             )
-            ]),
+    'preselection' : OrderedDict(),
+        # Commented out because of 80X jet cleaning memory leak
+        #[
+        #    # Remove jets that overlap our leptons
+        #    ('j', { # Made pt requirement for E/Mu to clean an overlapping jet so
+        #            # that this never happens
+        #            'selection' : 'pt > 20 && abs(eta) < 4.7 && userFloat("idLoose") > 0.5',
+        #            'e' : {
+        #                'deltaR' : 0.5,
+        #                'selection' : 'userFloat("MVANonTrigWP90") > 0.5 && pt > 9999 && abs(eta) < 2.5',
+        #                },
+        #            'm' : {
+        #                'deltaR' : 0.5,
+        #                'selection' : 'isMediumMuon() > 0.5 && pt > 9999 && abs(eta) < 2.4',
+        #                },
+        #            }
+        #     )
+        #    ]),
 
     # selections to include object in final state (should be looser than analysis selections)
     # Based on default finalSelection, this is a little tighter for muons so we keep the min Pt Mu for our triggers
@@ -202,7 +203,7 @@ parameters = {
 
     'tauVariables' : PSet(
         
-        objectL1IsoTauMatch = 'l1extraIsoTauMatching({object_idx})',
+        #objectL1IsoTauMatch = 'l1extraIsoTauMatching({object_idx})',
         # Sync Triggers
         objectMatchesDoubleTau40Filter = 'matchToHLTFilter({object_idx}, "hltDoublePFTau40TrackPt1MediumIsolationDz02Reg", 0.5)',
         objectMatchesDoubleTau40Path      = r'matchToHLTPath({object_idx}, "HLT_DoubleMediumIsoPFTau40_Trk1_eta2p1_Reg_v\\d+", 0.5)',
@@ -240,6 +241,6 @@ parameters = {
         #object1_object2_MvaMetCovMatrix10 = 'getMVAMET({object1_idx},{object2_idx}).at(3)',
         #object1_object2_MvaMetCovMatrix01 = 'getMVAMET({object1_idx},{object2_idx}).at(4)',
         #object1_object2_MvaMetCovMatrix11 = 'getMVAMET({object1_idx},{object2_idx}).at(5)',
-        object1_object2_doubleL1IsoTauMatch = 'doubleL1extraIsoTauMatching({object1_idx},{object2_idx})',
+        #object1_object2_doubleL1IsoTauMatch = 'doubleL1extraIsoTauMatching({object1_idx},{object2_idx})',
     ),
 }

--- a/PatTools/plugins/PATFinalStateEventProducer.cc
+++ b/PatTools/plugins/PATFinalStateEventProducer.cc
@@ -91,7 +91,7 @@ private:
 
   edm::EDGetTokenT<pat::PackedTriggerPrescales> trgPrescaleSrcToken_;
   edm::EDGetTokenT<edm::TriggerResults> trgResultsSrcToken_;
-  edm::EDGetTokenT< std::vector< l1extra::L1JetParticle > > l1extraIsoTauSrcToken_;
+  //edm::EDGetTokenT< std::vector< l1extra::L1JetParticle > > l1extraIsoTauSrcToken_;
 
   //edm::EDGetTokenT<pat::JetCollection> jetAK8SrcToken_;
 
@@ -131,7 +131,7 @@ PATFinalStateEventProducer::PATFinalStateEventProducer(
     pset.getParameter<bool>("forbidMissing") : true;
 
   trgResultsSrcToken_ = consumes<edm::TriggerResults>(pset.getParameter<edm::InputTag>("trgResultsSrc"));
-  l1extraIsoTauSrcToken_ = consumes< std::vector< l1extra::L1JetParticle > >(pset.getParameter<edm::InputTag>("l1extraIsoTauSrc"));
+  //l1extraIsoTauSrcToken_ = consumes< std::vector< l1extra::L1JetParticle > >(pset.getParameter<edm::InputTag>("l1extraIsoTauSrc"));
 
   //photonCoreSrcToken_ = consumes<edm::InputTag>(pset.getParameter<edm::InputTag>("photonCoreSrc"));
   //gsfCoreSrcToken_ = consumes<edm::InputTag>(pset.getParameter<edm::InputTag>("gsfCoreSrc"));
@@ -267,8 +267,8 @@ void PATFinalStateEventProducer::produce(edm::Event& evt,
   const edm::TriggerNames& names = evt.triggerNames(*trigResults);
   evt.getByToken(trgPrescaleSrcToken_, trigPrescale);
 
-  edm::Handle< std::vector<l1extra::L1JetParticle> > l1extraIsoTaus;
-  evt.getByToken(l1extraIsoTauSrcToken_, l1extraIsoTaus);
+  //edm::Handle< std::vector<l1extra::L1JetParticle> > l1extraIsoTaus;
+  //evt.getByToken(l1extraIsoTauSrcToken_, l1extraIsoTaus);
 
   edm::Handle<std::vector<PileupSummaryInfo> > puInfo;
   evt.getByToken(puInfoSrcToken_, puInfo);
@@ -318,7 +318,8 @@ void PATFinalStateEventProducer::produce(edm::Event& evt,
 
   pat::TriggerEvent trg;
   PATFinalStateEvent theEvent(*rho, pvPtr, verticesPtr, metPtr, metCovariance, MVAMETInfo,
-                              trg, trigStandAlone, names, *trigPrescale, *trigResults, *l1extraIsoTaus, myPuInfo, genInfo, genParticlesRef, 
+                              //trg, trigStandAlone, names, *trigPrescale, *trigResults, *l1extraIsoTaus, myPuInfo, genInfo, genParticlesRef, 
+                              trg, trigStandAlone, names, *trigPrescale, *trigResults, myPuInfo, genInfo, genParticlesRef, 
                               evt.id(), genEventInfo, generatorFilter, evt.isRealData(), puScenario_,
                               electronRefProd, muonRefProd, tauRefProd, jetRefProd,
                               phoRefProd, pfRefProd, packedPFRefProd, trackRefProd, gsftrackRefProd, theMEts);

--- a/PatTools/python/finalStates/patFinalStateEventProducer_cfi.py
+++ b/PatTools/python/finalStates/patFinalStateEventProducer_cfi.py
@@ -32,7 +32,7 @@ patFinalStateEventProducer = cms.EDProducer(
     # now some miniAOD specific stuff
     trgPrescaleSrc = cms.InputTag("patTrigger"),
     trgResultsSrc = cms.InputTag("TriggerResults","","HLT"),
-    l1extraIsoTauSrc = cms.InputTag("l1extraParticles","IsoTau","RECO"),
+    #l1extraIsoTauSrc = cms.InputTag("l1extraParticles","IsoTau","RECO"),
     packedGenSrc = cms.InputTag("packedGenParticles"),
     packedPFSrc = cms.InputTag("packedPFCandidates"),
     jetAK8Src = cms.InputTag("slimmedJetsAK8"),

--- a/Utilities/scripts/submit_job.py
+++ b/Utilities/scripts/submit_job.py
@@ -133,7 +133,8 @@ def getFarmoutCommand(args, dataset_name, full_dataset_name):
 
     # temp hardcode
     if args.apply_cms_lumimask:
-        filename = 'Cert_271036-275125_13TeV_PromptReco_Collisions16_JSON.txt' # 3.99/fb - June 22
+        #filename = 'Cert_271036-275125_13TeV_PromptReco_Collisions16_JSON.txt' # 3.99/fb - June 22
+        filename = 'Cert_271036-276811_13TeV_PromptReco_Collisions16_JSON_NoL1T.txt' # 12.9/fb - July 20, no L1Trig check
         lumi_mask_path = os.path.join('/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV',filename)
         if args.lumimaskjson: 
             assert not (args.silver or args.goldenv2), "ERROR: Multiple lumimask jsons specified"


### PR DESCRIPTION
1. Updating to new 12.9/fb lumi mask (note that the L1Trig is not validated on the newest data but that is rarely a problem)
2. Commenting out l1extra tau matching because those products are not in some of the reHLT samples in 80X
3. Changed 'preselection' in my parameter files to a blank OrderedDict() to skip the use of the jet cleaning module which, since 80X eats up lots of memory and causes jobs to fail.  This is a temporary fix, jet cleaning needs to be added back in other ways.
