### PR TITLE
This fixes the code for HTT when we don't run with all 27 JES

### DIFF
--- a/NtupleTools/python/ntuple_builder.py
+++ b/NtupleTools/python/ntuple_builder.py
@@ -219,7 +219,7 @@ def make_ntuple(*legs, **kwargs):
             templates.topology.fullJES
         )
 
-    if isShiftedMet:
+    if isShiftedMet and fullJES:
         ntuple_config = PSet(
             ntuple_config,
             templates.event.shiftedMet


### PR DESCRIPTION
LFV folks, please let me know if this minor change is a problem for you.  The way your code has changed general FSA running requires running on all 27 JES (fullJES=1) or metShift=0.

https://github.com/uwcms/FinalStateAnalysis/blob/miniAOD_8_0_25/NtupleTools/test/make_ntuples_cfg.py#L125

Please make the code a little more helpful for us :-)

Can I set default metShift=0?