### PR TITLE
Fixing mega-farmout for merging to work

### DIFF
--- a/PlotTools/scripts/mega-farmout
+++ b/PlotTools/scripts/mega-farmout
@@ -113,7 +113,7 @@ if __name__ == "__main__":
             '--submit-dir=%s/analyze' % working_dir,
             '--input-file-list=%s' % tmp_input_filelist.name,
             '--input-files-per-job=%i' % args.filesinjob,
-            '--output-dir=%s' % (output_path),
+            #'--output-dir=%s' % (output_path),
             '--fwklite',
             '--infer-cmssw-path',
             '--output-dag-file=%s/job.dag' % working_dir,
@@ -156,7 +156,7 @@ if __name__ == "__main__":
                 '--last-submit-dir=%s' % previous_submit_dir,
                 '--output-dag-file=%s/job.dag' % working_dir,
                 '--input-files-per-job=%i' % args.filesinmerge,
-                '--output-dir=%s' % (output_path),
+                #'--output-dir=%s' % (output_path),
                 '--infer-cmssw-path',
                 '--merge',
                 '--use-hadd'


### PR DESCRIPTION
When submitting analysis jobs from UWHiggs the merging(hadd) is failing. This is because in mega-farmout the output-dir is appended with the SRM Server "srm://cmssrm2.hep.wisc.edu:8443/srm/v2/server?SFN=" as can be seen in the inputs folder of merging

Example - root://cmsxrootd.hep.wisc.edu/srm://cmssrm2.hep.wisc.edu:8443/srm/v2/server?SFN=/hdfs/store/user/psiddire/MegaJob_tmp0LPFhRNewAnalyzeM\
uTau-DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8//mega-batch-make_ntuples_cfg-6CFE0918-83FC-E711-9E70-001E67E340DE.root  

Because of this we are getting the following error: Error in <TFileMerger::AddFile>

In order to resolve this, I commented the output-dir line in mega-farmout. The result of this is that farmoutAnalysisJobs uses the default server: "SRM_SERVER=gsiftp://cms-lvs-gridftp.hep.wisc.edu:2811//hdfs" without appending anything to the output files. In this way, the output files can be accessed by <TFileMerger::AddFile> service. 

I cross-checked the output files with the ones which are locally run and produced and they match perfectly.  
