### PR TITLE
Apply JEC to embedded in 2017

### DIFF
--- a/DataAlgos/src/VBFSelections.cc
+++ b/DataAlgos/src/VBFSelections.cc
@@ -21,7 +21,9 @@ VBFVariables computeVBFInfo(
   if (output.nJets < 2)
     return output;
 
-  assert(jets[0]->pt() > jets[1]->pt());
+  assert( (jets[0]->pt() > jets[1]->pt()) || (jets[0]->pt() == jets[1]->pt() && jets[0]->eta() != jets[1]->eta()) );
+  // We are seeing some jets with the same pT to 6 decimals but different eta/phi.  Don't crash!
+  // Could check phi too but thats excessive
 
   reco::Candidate::LorentzVector leadJet;
   reco::Candidate::LorentzVector subleadJet;

--- a/NtupleTools/test/make_ntuples_cfg.py
+++ b/NtupleTools/test/make_ntuples_cfg.py
@@ -358,9 +358,10 @@ process.pileupJetIdUpdated = process.pileupJetId.clone(
 
 # FIXME - this is temporary and only for 2017 analyses using 31March2018 data rereco. It needs
 # to be update once the recommended data samples change.
+# 2017 Embedded samples are produced with 17Nov2017 data, NOT 31March2018, so they need JEC
 from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
 isData = not options.isMC
-if options.isMC :
+if options.isMC or options.isEmbedded :
     process.load ("CondCore.CondDB.CondDB_cfi")
     #from CondCore.CondDB.CondDB_cfi import *
     


### PR DESCRIPTION
Fix for #607  to include JEC on embedded 2017 samples as well as MC