### PR TITLE
trigger filter matching in embedded samples

### DIFF
--- a/NtupleTools/python/customization_electrons.py
+++ b/NtupleTools/python/customization_electrons.py
@@ -4,7 +4,7 @@ from PhysicsTools.SelectorUtils.tools.vid_id_tools import setupAllVIDIdsInModule
 #from EgammaAnalysis.ElectronTools.regressionWeights_cfi import regressionWeights
 
 
-def preElectrons(process, eSrc, vSrc, year, **kwargs):
+def preElectrons(process, eSrc, vSrc, year, isEmbedded, **kwargs):
     postfix = kwargs.pop('postfix','')
 
     from RecoEgamma.EgammaTools.EgammaPostRecoTools import setupEgammaPostRecoSeq
@@ -74,6 +74,27 @@ def preElectrons(process, eSrc, vSrc, year, **kwargs):
     pathName = 'electronRhoEmbedding{0}'.format(postfix)
     path = cms.Path(getattr(process,modName))
     setattr(process,pathName,path)
+    process.schedule.append(getattr(process,pathName))
+
+    # embed trigger filters
+    modName = 'minitriggerfilterElectrons{0}'.format(postfix)
+    mod = cms.EDProducer(
+        "MiniAODElectronTriggerFilterEmbedder",
+        src=cms.InputTag(eSrc),
+        bits = cms.InputTag("TriggerResults","","HLT"),
+        objects = cms.InputTag("slimmedPatTrigger"),
+        #bits = cms.InputTag("TriggerResults","","SIMembedding"),
+        #objects = cms.InputTag("slimmedPatTrigger","","MERGE"),
+    )
+    if isEmbedded:
+	mod.bits=cms.InputTag("TriggerResults","","SIMembedding")
+	mod.objects=cms.InputTag("slimmedPatTrigger","","MERGE")
+    eSrc = modName
+    setattr(process,modName,mod)
+
+    pathName = 'runTriggerFilterElectronEmbedding{0}'.format(postfix)
+    modPath = cms.Path(getattr(process,modName))
+    setattr(process,pathName,modPath)
     process.schedule.append(getattr(process,pathName))
 
     # embed WW ID

--- a/NtupleTools/python/customization_muons.py
+++ b/NtupleTools/python/customization_muons.py
@@ -1,7 +1,7 @@
 # Embed IDs for muons
 import FWCore.ParameterSet.Config as cms
 
-def preMuons(process, mSrc, vSrc, **kwargs):
+def preMuons(process, isEmbedded, mSrc, vSrc, **kwargs):
     postfix = kwargs.pop('postfix','')
 
     # embed ids
@@ -13,8 +13,29 @@ def preMuons(process, mSrc, vSrc, **kwargs):
     )
     mSrc = modName
     setattr(process,modName,mod)
-    
+
     pathName = 'runMiniAODMuonEmbedding{0}'.format(postfix)
+    modPath = cms.Path(getattr(process,modName))
+    setattr(process,pathName,modPath)
+    process.schedule.append(getattr(process,pathName))
+
+    # embed trigger filters
+    modName = 'minitriggerfilterMuons{0}'.format(postfix)
+    mod = cms.EDProducer(
+        "MiniAODMuonTriggerFilterEmbedder",
+        src=cms.InputTag(mSrc),
+        bits = cms.InputTag("TriggerResults","","HLT"),
+        objects = cms.InputTag("slimmedPatTrigger"),
+        #bits = cms.InputTag("TriggerResults","","SIMembedding"),
+        #objects = cms.InputTag("slimmedPatTrigger","","MERGE"),
+    )
+    if isEmbedded:
+        mod.bits=cms.InputTag("TriggerResults","","SIMembedding")
+        mod.objects=cms.InputTag("slimmedPatTrigger","","MERGE")
+    mSrc = modName
+    setattr(process,modName,mod)
+    
+    pathName = 'runTriggerFilterMuonEmbedding{0}'.format(postfix)
     modPath = cms.Path(getattr(process,modName))
     setattr(process,pathName,modPath)
     process.schedule.append(getattr(process,pathName))

--- a/NtupleTools/python/customization_taus.py
+++ b/NtupleTools/python/customization_taus.py
@@ -44,7 +44,7 @@ def getDeepTauVersion(file_name):
         return int(year), int(version), int(subversion)
 
 
-def preTaus(process, tSrc, vSrc,**kwargs):
+def preTaus(process, isEmbedded, tSrc, vSrc,**kwargs):
 
     postfix = kwargs.pop('postfix','')
     rerunMvaIDs = bool(kwargs.pop('rerunMvaIDs', 0))
@@ -745,6 +745,28 @@ def preTaus(process, tSrc, vSrc,**kwargs):
     path = cms.Path(getattr(process,modName))
     setattr(process,pathName,path)
     process.schedule.append(getattr(process,pathName))
+
+    # embed trigger filters
+    modName = 'minitriggerfilterTaus{0}'.format(postfix)
+    mod = cms.EDProducer(
+        "MiniAODTauTriggerFilterEmbedder",
+        src=cms.InputTag(tSrc),
+        bits = cms.InputTag("TriggerResults","","HLT"),
+        objects = cms.InputTag("slimmedPatTrigger"),
+        #bits = cms.InputTag("TriggerResults","","SIMembedding"),
+        #objects = cms.InputTag("slimmedPatTrigger","","MERGE"),
+    )
+    if isEmbedded:
+        mod.bits=cms.InputTag("TriggerResults","","SIMembedding")
+        mod.objects=cms.InputTag("slimmedPatTrigger","","MERGE")
+    tSrc = modName
+    setattr(process,modName,mod)
+
+    pathName = 'runTriggerFilterTauEmbedding{0}'.format(postfix)
+    modPath = cms.Path(getattr(process,modName))
+    setattr(process,pathName,modPath)
+    process.schedule.append(getattr(process,pathName))
+
 
 
     return tSrc

--- a/NtupleTools/python/parameters/ztt.py
+++ b/NtupleTools/python/parameters/ztt.py
@@ -308,6 +308,7 @@ parameters = {
 
         objectMatchesEle24Tau30Filter= r'matchToHLTFilter({object_idx}, "HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTau30_eta2p1_CrossL1_v\\d+", 0.5)',
         objectMatchesEle24HPSTau30Filter= r'matchToHLTFilter({object_idx}, "HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTauHPS30_eta2p1_CrossL1_v\\d+", 0.5)',
+        #objectMatchesEle24Tau30EmbeddedFilter= r'matchToGivenHLTFilter({object_idx}, "hltEle24erWPTightGsfTrackIsoFilterForTau", 0.5)',
         objectMatchesEle25Filter= r'matchToHLTFilter({object_idx}, "HLT_Ele25_eta2p1_WPTight_Gsf_v\\d+", 0.5)',
         objectMatchesEle32Filter= r'matchToHLTFilter({object_idx}, "HLT_Ele32_WPTight_Gsf_v\\d+", 0.5)',
         objectMatchesEle27Filter= r'matchToHLTFilter({object_idx}, "HLT_Ele27_WPTight_Gsf_v\\d+", 0.5)',
@@ -320,6 +321,13 @@ parameters = {
         objectMatchesMu23e12Path= r'matchToHLTPath({object_idx}, "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v\\d+", 0.5)',
         objectMatchesMu8e23DZPath= r'matchToHLTPath({object_idx}, "HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v\\d+", 0.5)',
         objectMatchesMu8e23Path= r'matchToHLTPath({object_idx}, "HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v\\d+", 0.5)',
+
+        objectMatchEmbeddedFilterEle27 = '? {object}.hasUserInt("matchEmbeddedFilterEle27") ? {object}.userInt("matchEmbeddedFilterEle27") : -10',
+        objectMatchEmbeddedFilterEle32 = '? {object}.hasUserInt("matchEmbeddedFilterEle32") ? {object}.userInt("matchEmbeddedFilterEle32") : -10',
+        objectMatchEmbeddedFilterEle32DoubleL1_v1 = '? {object}.hasUserInt("matchEmbeddedFilterEle32DoubleL1_v1") ? {object}.userInt("matchEmbeddedFilterEle32DoubleL1_v1") : -10',
+        objectMatchEmbeddedFilterEle32DoubleL1_v2 = '? {object}.hasUserInt("matchEmbeddedFilterEle32DoubleL1_v2") ? {object}.userInt("matchEmbeddedFilterEle32DoubleL1_v2") : -10',
+        objectMatchEmbeddedFilterEle35 = '? {object}.hasUserInt("matchEmbeddedFilterEle35") ? {object}.userInt("matchEmbeddedFilterEle35") : -10',
+        objectMatchEmbeddedFilterEle24Tau30 = '? {object}.hasUserInt("matchEmbeddedFilterEle24Tau30") ? {object}.userInt("matchEmbeddedFilterEle24Tau30") : -10',
 
         objectGenIsPrompt       = '? (getDaughterGenParticle({object_idx}, 11, 0).isAvailable && getDaughterGenParticle({object_idx}, 11, 0).isNonnull) ? getDaughterGenParticle({object_idx}, 11, 0).statusFlags().isPrompt() : -999',
         objectGenDirectPromptTauDecay       = '? {object}.genParticleRef.isNonnull?  {object}.genParticleRef().statusFlags().isDirectPromptTauDecayProduct() : -999',
@@ -363,6 +371,12 @@ parameters = {
         objectMatchesMu23e12Path= r'matchToHLTPath({object_idx}, "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v\\d+", 0.5)',
         objectMatchesMu8e23DZPath= r'matchToHLTPath({object_idx}, "HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v\\d+", 0.5)',
         objectMatchesMu8e23Path= r'matchToHLTPath({object_idx}, "HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v\\d+", 0.5)',
+
+        objectMatchEmbeddedFilterMu24 = '? {object}.hasUserInt("matchEmbeddedFilterMu24") ? {object}.userInt("matchEmbeddedFilterMu24") : -10',
+        objectMatchEmbeddedFilterMu27 = '? {object}.hasUserInt("matchEmbeddedFilterMu27") ? {object}.userInt("matchEmbeddedFilterMu27") : -10',
+        objectMatchEmbeddedFilterMu20Tau27_2017 = '? {object}.hasUserInt("matchEmbeddedFilterMu20Tau27_2017") ? {object}.userInt("matchEmbeddedFilterMu20Tau27_2017") : -10',
+        objectMatchEmbeddedFilterMu20Tau27_2018 = '? {object}.hasUserInt("matchEmbeddedFilterMu20Tau27_2018") ? {object}.userInt("matchEmbeddedFilterMu20Tau27_2018") : -10',
+
 
         objectGenIsPrompt       = '? (getDaughterGenParticle({object_idx}, 13, 0).isAvailable && getDaughterGenParticle({object_idx}, 13, 0).isNonnull) ? getDaughterGenParticle({object_idx}, 13, 0).statusFlags().isPrompt() : -999',
         objectGenDirectPromptTauDecayFinalState       = '? {object}.genParticleRef.isNonnull?  {object}.genParticleRef().isDirectPromptTauDecayProductFinalState() : -999',
@@ -413,7 +427,12 @@ parameters = {
         objectMatchesDoubleTauCmbIso35RegPath = r'matchToHLTPath({object_idx}, "HLT_DoubleMediumCombinedIsoPFTau35_Trk1_eta2p1_Reg_v\\d+", 0.5)',
         objectMatchesDoubleTau35Filter = r'matchToHLTFilter({object_idx}, "HLT_DoubleMediumIsoPFTau35_Trk1_eta2p1_Reg_v\\d", 0.5)',
         objectMatchesDoubleTau35Path = r'matchToHLTPath({object_idx}, "HLT_DoubleMediumIsoPFTau35_Trk1_eta2p1_Reg_v\\d+", 0.5)',
-          
+
+        objectMatchEmbeddedFilterMu20Tau27 = '? {object}.hasUserInt("matchEmbeddedFilterMu20Tau27") ? {object}.userInt("matchEmbeddedFilterMu20Tau27") : -10',
+        objectMatchEmbeddedFilterMu20HPSTau27 = '? {object}.hasUserInt("matchEmbeddedFilterMu20HPSTau27") ? {object}.userInt("matchEmbeddedFilterMu20HPSTau27") : -10',
+        objectMatchEmbeddedFilterEle24Tau30 = '? {object}.hasUserInt("matchEmbeddedFilterEle24Tau30") ? {object}.userInt("matchEmbeddedFilterEle24Tau30") : -10',
+        objectMatchEmbeddedFilterTauTau = '? {object}.hasUserInt("matchEmbeddedFilterTauTau") ? {object}.userInt("matchEmbeddedFilterTauTau") : -10',
+
         #objectDoubleL2IsoTau26Filter = 'matchToHLTFilter2({object_idx}, "hltDoubleL2IsoTau26eta2p2", 0.5)',
         
         objectZTTGenMatching = 'tauGenMatch2({object_idx})', 

--- a/NtupleTools/test/make_ntuples_cfg.py
+++ b/NtupleTools/test/make_ntuples_cfg.py
@@ -707,6 +707,7 @@ fs_daughter_inputs['electrons'] = preElectrons(process,
                                                fs_daughter_inputs['electrons'],
                                                fs_daughter_inputs['vertices'],
                                                options.era,
+					       bool(options.isEmbedded),
                                                electronMVAGeneralIDLabel=electronMVAGeneralIDLabel,
                                                electronMVAHzzIDLabel=electronMVAHzzIDLabel,
                                                applyEnergyCorrections=bool(options.eCalib),
@@ -768,10 +769,12 @@ process.schedule.append(process.METSigSeq)
 
 from FinalStateAnalysis.NtupleTools.customization_muons import preMuons
 fs_daughter_inputs['muons'] = preMuons(process,
+                                       bool(options.isEmbedded),
                                        fs_daughter_inputs['muons'],
                                        fs_daughter_inputs['vertices'])
 for fs in additional_fs:
     additional_fs[fs]['muons'] = preMuons(process,
+					  bool(options.isEmbedded),
                                           additional_fs[fs]['muons'],
                                           additional_fs[fs]['vertices'],
                                           postfix=fs)
@@ -781,11 +784,13 @@ for fs in additional_fs:
 #####################
 from FinalStateAnalysis.NtupleTools.customization_taus import preTaus
 fs_daughter_inputs['taus'] = preTaus(process,
+                                     bool(options.isEmbedded),
                                      fs_daughter_inputs['taus'],
                                      fs_daughter_inputs['vertices'],
                                      rerunMvaIDs=options.htt)
 for fs in additional_fs:
     additional_fs[fs]['taus'] = preTaus(process,
+	                                bool(options.isEmbedded),
                                         additional_fs[fs]['taus'],
                                         additional_fs[fs]['vertices'],
                                         postfix=fs,

--- a/PatTools/plugins/MiniAODElectronTriggerFilterEmbedder.cc
+++ b/PatTools/plugins/MiniAODElectronTriggerFilterEmbedder.cc
@@ -1,0 +1,117 @@
+/*
+ * Embeds the trigger filters
+ * Author: Cecile Caillol, UW-Madison
+ */
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
+
+#include "DataFormats/PatCandidates/interface/Electron.h"
+
+#include <math.h>
+
+// class declaration
+class MiniAODElectronTriggerFilterEmbedder : public edm::EDProducer {
+  public:
+    explicit MiniAODElectronTriggerFilterEmbedder(const edm::ParameterSet& pset);
+    virtual ~MiniAODElectronTriggerFilterEmbedder(){}
+    void produce(edm::Event& evt, const edm::EventSetup& es);
+
+  private:
+    edm::EDGetTokenT<pat::ElectronCollection> electronsCollection_;
+    edm::EDGetTokenT<edm::TriggerResults> triggerBits_;
+    edm::EDGetTokenT<pat::TriggerObjectStandAloneCollection> triggerObjects_;
+};
+
+// class member functions
+MiniAODElectronTriggerFilterEmbedder::MiniAODElectronTriggerFilterEmbedder(const edm::ParameterSet& pset) {
+  electronsCollection_ = consumes<pat::ElectronCollection>(pset.getParameter<edm::InputTag>("src"));
+  triggerBits_ = consumes<edm::TriggerResults>(pset.getParameter<edm::InputTag>("bits"));
+  triggerObjects_ = consumes<pat::TriggerObjectStandAloneCollection>(pset.getParameter<edm::InputTag>("objects"));
+
+  produces<pat::ElectronCollection>();
+}
+
+void MiniAODElectronTriggerFilterEmbedder::produce(edm::Event& evt, const edm::EventSetup& es) {
+  edm::Handle<std::vector<pat::Electron>> electronsCollection;
+  evt.getByToken(electronsCollection_ , electronsCollection);
+
+  edm::Handle<edm::TriggerResults> triggerBits;
+  edm::Handle<pat::TriggerObjectStandAloneCollection> triggerObjects;
+  evt.getByToken(triggerBits_, triggerBits);
+  evt.getByToken(triggerObjects_, triggerObjects);
+
+  const edm::TriggerNames &names = evt.triggerNames(*triggerBits);
+
+  const std::vector<pat::Electron> * electrons = electronsCollection.product();
+
+  unsigned int nbElectron =  electrons->size();
+
+  std::unique_ptr<pat::ElectronCollection> output(new pat::ElectronCollection);
+  output->reserve(nbElectron);
+
+  for(unsigned i = 0 ; i < nbElectron; i++){
+    pat::Electron electron(electrons->at(i));
+    int matchEle27=0;
+    int matchEle32=0;
+    int matchEle32DoubleL1_v1=0;
+    int matchEle32DoubleL1_v2=0;
+    int matchEle35=0;
+    int matchEle24Tau30=0;
+    for (pat::TriggerObjectStandAlone obj : *triggerObjects) {
+        if (reco::deltaR(electron, obj) > 0.5) continue;
+        obj.unpackPathNames(names);
+        obj.unpackFilterLabels(evt,*triggerBits.product());
+
+        for (unsigned h = 0; h < obj.filterLabels().size(); ++h) {
+          std::string filter = obj.filterLabels()[h];
+          if (filter.compare("hltEle27WPTightGsfTrackIsoFilter")==0) {
+               matchEle27++;
+          }
+          if (filter.compare("hltEle32WPTightGsfTrackIsoFilter")==0) {
+               matchEle32++;
+          }
+          if (filter.compare("hltEle32L1DoubleEGWPTightGsfTrackIsoFilter")==0) {
+               matchEle32DoubleL1_v1++;
+          }
+          if (filter.compare("hltEGL1SingleEGOrFilter")==0) {
+               matchEle32DoubleL1_v2++;
+          }
+          if (filter.compare("hltEle35noerWPTightGsfTrackIsoFilter")==0) {
+               matchEle35++;
+          }
+          if (filter.compare("hltEle24erWPTightGsfTrackIsoFilterForTau")==0) {
+               matchEle24Tau30++;
+          }
+        }
+    }
+
+    electron.addUserInt("matchEmbeddedFilterEle27",matchEle27);
+    electron.addUserInt("matchEmbeddedFilterEle32",matchEle32);
+    electron.addUserInt("matchEmbeddedFilterEle32DoubleL1_v1",matchEle32DoubleL1_v1);
+    electron.addUserInt("matchEmbeddedFilterEle32DoubleL1_v2",matchEle32DoubleL1_v2);
+    electron.addUserInt("matchEmbeddedFilterEle35",matchEle35);
+    electron.addUserInt("matchEmbeddedFilterEle24Tau30",matchEle24Tau30);
+
+    output->push_back(electron);
+  }
+
+  evt.put(std::move(output));
+}
+
+// define plugin
+DEFINE_FWK_MODULE(MiniAODElectronTriggerFilterEmbedder);

--- a/PatTools/plugins/MiniAODMuonTriggerFilterEmbedder.cc
+++ b/PatTools/plugins/MiniAODMuonTriggerFilterEmbedder.cc
@@ -1,0 +1,107 @@
+/*
+ * Embeds the trigger filters
+ * Author: Cecile Caillol, UW-Madison
+ */
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
+
+#include "DataFormats/PatCandidates/interface/Muon.h"
+
+#include <math.h>
+
+// class declaration
+class MiniAODMuonTriggerFilterEmbedder : public edm::EDProducer {
+  public:
+    explicit MiniAODMuonTriggerFilterEmbedder(const edm::ParameterSet& pset);
+    virtual ~MiniAODMuonTriggerFilterEmbedder(){}
+    void produce(edm::Event& evt, const edm::EventSetup& es);
+
+  private:
+    edm::EDGetTokenT<pat::MuonCollection> muonsCollection_;
+    edm::EDGetTokenT<edm::TriggerResults> triggerBits_;
+    edm::EDGetTokenT<pat::TriggerObjectStandAloneCollection> triggerObjects_;
+};
+
+// class member functions
+MiniAODMuonTriggerFilterEmbedder::MiniAODMuonTriggerFilterEmbedder(const edm::ParameterSet& pset) {
+  muonsCollection_ = consumes<pat::MuonCollection>(pset.getParameter<edm::InputTag>("src"));
+  triggerBits_ = consumes<edm::TriggerResults>(pset.getParameter<edm::InputTag>("bits"));
+  triggerObjects_ = consumes<pat::TriggerObjectStandAloneCollection>(pset.getParameter<edm::InputTag>("objects"));
+
+  produces<pat::MuonCollection>();
+}
+
+void MiniAODMuonTriggerFilterEmbedder::produce(edm::Event& evt, const edm::EventSetup& es) {
+  edm::Handle<std::vector<pat::Muon>> muonsCollection;
+  evt.getByToken(muonsCollection_ , muonsCollection);
+
+  edm::Handle<edm::TriggerResults> triggerBits;
+  edm::Handle<pat::TriggerObjectStandAloneCollection> triggerObjects;
+  evt.getByToken(triggerBits_, triggerBits);
+  evt.getByToken(triggerObjects_, triggerObjects);
+
+  const edm::TriggerNames &names = evt.triggerNames(*triggerBits);
+
+  const std::vector<pat::Muon> * muons = muonsCollection.product();
+
+  unsigned int nbMuon =  muons->size();
+
+  std::unique_ptr<pat::MuonCollection> output(new pat::MuonCollection);
+  output->reserve(nbMuon);
+
+  for(unsigned i = 0 ; i < nbMuon; i++){
+    pat::Muon muon(muons->at(i));
+    int matchMu24=0;
+    int matchMu27=0;
+    int matchMu20Tau27_2018=0;
+    int matchMu20Tau27_2017=0;
+    for (pat::TriggerObjectStandAlone obj : *triggerObjects) {
+        if (reco::deltaR(muon, obj) > 0.5) continue;
+        obj.unpackPathNames(names);
+        obj.unpackFilterLabels(evt,*triggerBits.product());
+
+        for (unsigned h = 0; h < obj.filterLabels().size(); ++h) {
+          std::string filter = obj.filterLabels()[h];
+          if (filter.compare("hltL3crIsoBigORMu18erTauXXer2p1L1f0L2f10QL3f20QL3trkIsoFiltered0p07")==0) {
+               matchMu20Tau27_2018++;
+          }
+          if (filter.compare("hltL3crIsoL1sMu18erTau24erIorMu20erTau24erL1f0L2f10QL3f20QL3trkIsoFiltered0p07")==0) {
+               matchMu20Tau27_2017++;
+          }
+          if (filter.compare("hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p07")==0) {
+               matchMu24++;
+          }
+          if (filter.compare("hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07")==0) {
+               matchMu27++;
+          }
+        }
+    }
+
+    muon.addUserInt("matchEmbeddedFilterMu24",matchMu24);
+    muon.addUserInt("matchEmbeddedFilterMu27",matchMu27);
+    muon.addUserInt("matchEmbeddedFilterMu20Tau27_2017",matchMu20Tau27_2017);
+    muon.addUserInt("matchEmbeddedFilterMu20Tau27_2018",matchMu20Tau27_2018);
+
+    output->push_back(muon);
+  }
+
+  evt.put(std::move(output));
+}
+
+// define plugin
+DEFINE_FWK_MODULE(MiniAODMuonTriggerFilterEmbedder);

--- a/PatTools/plugins/MiniAODTauTriggerFilterEmbedder.cc
+++ b/PatTools/plugins/MiniAODTauTriggerFilterEmbedder.cc
@@ -1,0 +1,107 @@
+/*
+ * Embeds the trigger filters
+ * Author: Cecile Caillol, UW-Madison
+ */
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
+
+#include "DataFormats/PatCandidates/interface/Tau.h"
+
+#include <math.h>
+
+// class declaration
+class MiniAODTauTriggerFilterEmbedder : public edm::EDProducer {
+  public:
+    explicit MiniAODTauTriggerFilterEmbedder(const edm::ParameterSet& pset);
+    virtual ~MiniAODTauTriggerFilterEmbedder(){}
+    void produce(edm::Event& evt, const edm::EventSetup& es);
+
+  private:
+    edm::EDGetTokenT<pat::TauCollection> tausCollection_;
+    edm::EDGetTokenT<edm::TriggerResults> triggerBits_;
+    edm::EDGetTokenT<pat::TriggerObjectStandAloneCollection> triggerObjects_;
+};
+
+// class member functions
+MiniAODTauTriggerFilterEmbedder::MiniAODTauTriggerFilterEmbedder(const edm::ParameterSet& pset) {
+  tausCollection_ = consumes<pat::TauCollection>(pset.getParameter<edm::InputTag>("src"));
+  triggerBits_ = consumes<edm::TriggerResults>(pset.getParameter<edm::InputTag>("bits"));
+  triggerObjects_ = consumes<pat::TriggerObjectStandAloneCollection>(pset.getParameter<edm::InputTag>("objects"));
+
+  produces<pat::TauCollection>();
+}
+
+void MiniAODTauTriggerFilterEmbedder::produce(edm::Event& evt, const edm::EventSetup& es) {
+  edm::Handle<std::vector<pat::Tau>> tausCollection;
+  evt.getByToken(tausCollection_ , tausCollection);
+
+  edm::Handle<edm::TriggerResults> triggerBits;
+  edm::Handle<pat::TriggerObjectStandAloneCollection> triggerObjects;
+  evt.getByToken(triggerBits_, triggerBits);
+  evt.getByToken(triggerObjects_, triggerObjects);
+
+  const edm::TriggerNames &names = evt.triggerNames(*triggerBits);
+
+  const std::vector<pat::Tau> * taus = tausCollection.product();
+
+  unsigned int nbTau =  taus->size();
+
+  std::unique_ptr<pat::TauCollection> output(new pat::TauCollection);
+  output->reserve(nbTau);
+
+  for(unsigned i = 0 ; i < nbTau; i++){
+    pat::Tau tau(taus->at(i));
+    int matchMu20Tau27=0;
+    int matchMu20HPSTau27=0;
+    int matchEle24Tau30=0;
+    int matchTauTau=0;
+    for (pat::TriggerObjectStandAlone obj : *triggerObjects) {
+        if (reco::deltaR(tau, obj) > 0.5) continue;
+        obj.unpackPathNames(names);
+        obj.unpackFilterLabels(evt,*triggerBits.product());
+
+        for (unsigned h = 0; h < obj.filterLabels().size(); ++h) {
+          std::string filter = obj.filterLabels()[h];
+          if (filter.compare("hltL1sMu18erTau24erIorMu20erTau24er")==0) {
+               matchMu20Tau27++;
+          }
+          if (filter.compare("hltL1sBigORMu18erTauXXer2p1")==0) {
+               matchMu20HPSTau27++;
+          }
+          if (filter.compare("hltL1sBigORLooseIsoEGXXerIsoTauYYerdRMin0p3")==0) {
+               matchEle24Tau30++;
+          }
+          if (filter.compare("hltDoubleL2IsoTau26eta2p2")==0) {
+               matchTauTau++;
+          }
+        }
+    }
+
+    tau.addUserInt("matchEmbeddedFilterMu20Tau27",matchMu20Tau27);
+    tau.addUserInt("matchEmbeddedFilterMu20HPSTau27",matchMu20HPSTau27);
+    tau.addUserInt("matchEmbeddedFilterEle24Tau30",matchEle24Tau30);
+    tau.addUserInt("matchEmbeddedFilterTauTau",matchTauTau);
+
+    output->push_back(tau);
+  }
+
+  evt.put(std::move(output));
+}
+
+// define plugin
+DEFINE_FWK_MODULE(MiniAODTauTriggerFilterEmbedder);


### PR DESCRIPTION
To be applied instead of path requirements in embedded samples. The filters are hardcoded in the producer, and userInts are attached to the muon, electron, and tau objects.