### PR TITLE
stage1_1_fine_cat for VBF th unc.

### DIFF
--- a/NtupleTools/python/parameters/ztt.py
+++ b/NtupleTools/python/parameters/ztt.py
@@ -66,9 +66,10 @@ parameters = {
 
         # Rivet code provides the Simplifed Template Cross Section values
         Rivet_stage0_cat='evt.getRivetInfo().stage0_cat',
-        Rivet_stage1_cat_pTjet25GeV='evt.getRivetInfo().stage1_cat_pTjet25GeV',
-        Rivet_stage1_cat_pTjet30GeV='evt.getRivetInfo().stage1_cat_pTjet30GeV',
-        Rivet_stage1p1_cat='evt.getRivetInfo().stage1p1_cat',
+        Rivet_stage1_1_cat_pTjet25GeV='evt.getRivetInfo().stage1_1_cat_pTjet25GeV',
+        Rivet_stage1_1_cat_pTjet30GeV='evt.getRivetInfo().stage1_1_cat_pTjet30GeV',
+        Rivet_stage1_1_fine_cat_pTjet25GeV='evt.getRivetInfo().stage1_1_fine_cat_pTjet25GeV',
+        Rivet_stage1_1_fine_cat_pTjet30GeV='evt.getRivetInfo().stage1_1_fine_cat_pTjet30GeV',
         Rivet_errorCode='evt.getRivetInfo().errorCode',
         Rivet_prodMode='evt.getRivetInfo().prodMode',
         Rivet_higgsPt='evt.getRivetInfo().higgs.pt()',

--- a/recipe/recipe_13TeV.sh
+++ b/recipe/recipe_13TeV.sh
@@ -40,20 +40,6 @@ git cms-addpkg RecoMET/METFilters
 cd $CMSSW_BASE/src
 git cms-addpkg SimDataFormats/HTXS
 git cms-addpkg GeneratorInterface/RivetInterface
-cd GeneratorInterface/RivetInterface/plugins/
-rm HTXSRivetProducer.cc
-wget https://raw.githubusercontent.com/amarini/cmssw/htxs_stage1p1_cmssw949_v2/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
-
-cd $CMSSW_BASE/src
-cd SimDataFormats/HTXS/interface/
-rm HiggsTemplateCrossSections.h
-wget https://raw.githubusercontent.com/amarini/cmssw/htxs_stage1p1_cmssw949_v2/SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h
-
-cd $CMSSW_BASE/src
-cd GeneratorInterface/RivetInterface/src/
-rm HiggsTemplateCrossSections.cc
-wget https://raw.githubusercontent.com/amarini/cmssw/htxs_stage1p1_cmssw949_v2/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
-
 
 popd
 


### PR DESCRIPTION
With this commit, the name of the Rivet variables changes and the values for the categories change too! Check https://gitlab.cern.ch/LHCHIGGSXS/LHCHXSWG2/STXS/Classification/blob/master/HiggsTemplateCrossSections.h to know the correspondence between numbers and categories. A fine Rivet binning is added too to compute the theoretical uncertainties, especially for the VBF signal